### PR TITLE
Clean up error reporting

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
@@ -104,6 +104,7 @@ public class KotlinTypeMapping implements JavaTypeMapping<Object> {
         return resolveType(type, signature, ownerFallBack);
     }
 
+    @Nullable
     private JavaType resolveType(Object type, String signature, @Nullable FirBasedSymbol<?> ownerFallBack) {
         if (type instanceof ConeTypeProjection) {
             return resolveConeTypeProjection((ConeTypeProjection) type, signature, ownerFallBack);
@@ -128,8 +129,6 @@ public class KotlinTypeMapping implements JavaTypeMapping<Object> {
                 return type(((FirValueParameterSymbol) resolvedSymbol).getResolvedReturnType(), ownerFallBack);
             } else if (resolvedSymbol instanceof FirFieldSymbol) {
                 return type(((FirFieldSymbol) resolvedSymbol).getResolvedReturnType(), ownerFallBack);
-            } else {
-                throw new IllegalArgumentException("Unsupported FirResolvedNamedReference: " + type.getClass().getName());
             }
         } else if (type instanceof FirResolvedTypeRef) {
             ConeKotlinType coneKotlinType = FirTypeUtilsKt.getConeType((FirResolvedTypeRef) type);
@@ -146,7 +145,7 @@ public class KotlinTypeMapping implements JavaTypeMapping<Object> {
             return type(((FirVariableAssignment) type).getCalleeReference(), ownerFallBack);
         }
 
-        throw new IllegalArgumentException("Unsupported type " + type.getClass().getName());
+        return null;
     }
 
     private JavaType.FullyQualified classType(Object classType, String signature, @Nullable FirBasedSymbol<?> ownerFallBack) {

--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.java
@@ -113,8 +113,6 @@ public class KotlinTypeSignatureBuilder implements JavaTypeSignatureBuilder {
                 return signature(((FirValueParameterSymbol) resolvedSymbol).getResolvedReturnType(), ownerSymbol);
             } else if (resolvedSymbol instanceof FirFieldSymbol) {
                 return signature(((FirFieldSymbol) resolvedSymbol).getResolvedReturnType(), ownerSymbol);
-            } else {
-                throw new IllegalArgumentException("Unsupported type " + type.getClass().getName());
             }
         } else if (type instanceof FirResolvedTypeRef) {
             ConeKotlinType coneKotlinType = ((FirResolvedTypeRef) type).getType();
@@ -137,7 +135,7 @@ public class KotlinTypeSignatureBuilder implements JavaTypeSignatureBuilder {
             return signature(((FirOuterClassTypeParameterRef) type).getSymbol());
         }
 
-        throw new IllegalArgumentException("Unsupported type " + type.getClass().getName());
+        return "{undefined}";
     }
 
     /**

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -3009,9 +3009,26 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
      */
     @Override
     public J visitElement(FirElement firElement, ExecutionContext ctx) {
+        // FIR error elements
         if (firElement instanceof FirErrorNamedReference) {
             return visitErrorNamedReference((FirErrorNamedReference) firElement, ctx);
-        } else if (firElement instanceof FirAnnotationCall) {
+        } else if (firElement instanceof FirErrorExpression) {
+            return visitErrorExpression((FirErrorExpression) firElement, ctx);
+        } else if (firElement instanceof FirErrorFunction) {
+            return visitErrorFunction((FirErrorFunction) firElement, ctx);
+        } else if (firElement instanceof FirErrorImport) {
+            return visitErrorImport((FirErrorImport) firElement, ctx);
+        } else if (firElement instanceof FirErrorLoop) {
+            return visitErrorLoop((FirErrorLoop) firElement, ctx);
+        } else if (firElement instanceof FirErrorProperty) {
+            return visitErrorProperty((FirErrorProperty) firElement, ctx);
+        } else if (firElement instanceof FirErrorResolvedQualifier) {
+            return visitErrorResolvedQualifier((FirErrorResolvedQualifier) firElement, ctx);
+        } else if (firElement instanceof FirErrorTypeRef) {
+            return visitErrorTypeRef((FirErrorTypeRef) firElement, ctx);
+        }
+
+        else if (firElement instanceof FirAnnotationCall) {
             return visitAnnotationCall((FirAnnotationCall) firElement, ctx);
         } else if (firElement instanceof FirAnonymousFunction) {
             return visitAnonymousFunction((FirAnonymousFunction) firElement, ctx);

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -21,10 +21,12 @@ import org.jetbrains.kotlin.KtSourceElement;
 import org.jetbrains.kotlin.descriptors.ClassKind;
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget;
 import org.jetbrains.kotlin.fir.*;
+import org.jetbrains.kotlin.fir.contracts.*;
 import org.jetbrains.kotlin.fir.declarations.*;
 import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertyGetter;
 import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertySetter;
 import org.jetbrains.kotlin.fir.declarations.impl.FirPrimaryConstructor;
+import org.jetbrains.kotlin.fir.diagnostics.FirDiagnosticHolder;
 import org.jetbrains.kotlin.fir.expressions.*;
 import org.jetbrains.kotlin.fir.expressions.impl.*;
 import org.jetbrains.kotlin.fir.references.*;
@@ -3111,6 +3113,132 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             return visitWhenSubjectExpression((FirWhenSubjectExpression) firElement, ctx);
         } else if (firElement instanceof FirWhileLoop) {
             return visitWhileLoop((FirWhileLoop) firElement, ctx);
+        }
+
+        // Not implemented yet.
+        else if (firElement instanceof FirArgumentList) {
+            return visitArgumentList((FirArgumentList) firElement, ctx);
+        } else if (firElement instanceof FirAugmentedArraySetCall) {
+            return visitAugmentedArraySetCall((FirAugmentedArraySetCall) firElement, ctx);
+        } else if (firElement instanceof FirAssignmentOperatorStatement) {
+            return visitAssignmentOperatorStatement((FirAssignmentOperatorStatement) firElement, ctx);
+        } else if (firElement instanceof FirAnonymousInitializer) {
+            return visitAnonymousInitializer((FirAnonymousInitializer) firElement, ctx);
+        } else if (firElement instanceof FirAnnotationArgumentMapping) {
+            return visitAnnotationArgumentMapping((FirAnnotationArgumentMapping) firElement, ctx);
+        } else if (firElement instanceof FirBackingField) {
+            return visitBackingField((FirBackingField) firElement, ctx);
+        } else if (firElement instanceof FirLegacyRawContractDescription) {
+            return visitLegacyRawContractDescription((FirLegacyRawContractDescription) firElement, ctx);
+        } else if (firElement instanceof FirRawContractDescription) {
+            return visitRawContractDescription((FirRawContractDescription) firElement, ctx);
+        } else if (firElement instanceof FirResolvedContractDescription) {
+            return visitResolvedContractDescription((FirResolvedContractDescription) firElement, ctx);
+        } else if (firElement instanceof FirContractDescription) {
+            return visitContractDescription((FirContractDescription) firElement, ctx);
+        } else if (firElement instanceof FirContextReceiver) {
+            return visitContextReceiver((FirContextReceiver) firElement, ctx);
+        } else if (firElement instanceof FirConstructor) {
+            return visitConstructor((FirConstructor) firElement, ctx);
+        } else if (firElement instanceof FirContractDescriptionOwner) {
+            return visitContractDescriptionOwner((FirContractDescriptionOwner) firElement, ctx);
+        } else if (firElement instanceof FirQualifiedAccessExpression) {
+            return visitQualifiedAccessExpression((FirQualifiedAccessExpression) firElement, ctx);
+        } else if (firElement instanceof FirQualifiedAccess) {
+            return visitQualifiedAccess((FirQualifiedAccess) firElement, ctx);
+        } else if (firElement instanceof FirContextReceiverArgumentListOwner) {
+            return visitContextReceiverArgumentListOwner((FirContextReceiverArgumentListOwner) firElement, ctx);
+        } else if (firElement instanceof FirClassReferenceExpression) {
+            return visitClassReferenceExpression((FirClassReferenceExpression) firElement, ctx);
+        } else if (firElement instanceof FirTypeAlias) {
+            return visitTypeAlias((FirTypeAlias) firElement, ctx);
+        } else if (firElement instanceof FirClassLikeDeclaration) {
+            return visitClassLikeDeclaration((FirClassLikeDeclaration) firElement, ctx);
+        } else if (firElement instanceof FirCall) {
+            return visitCall((FirCall) firElement, ctx);
+        } else if (firElement instanceof FirDynamicTypeRef) {
+            return visitDynamicTypeRef((FirDynamicTypeRef) firElement, ctx);
+        } else if (firElement instanceof FirResolvedDeclarationStatus) {
+            return visitResolvedDeclarationStatus((FirResolvedDeclarationStatus) firElement, ctx);
+        } else if (firElement instanceof FirDeclarationStatus) {
+            return visitDeclarationStatus((FirDeclarationStatus) firElement, ctx);
+        } else if (firElement instanceof FirEffectDeclaration) {
+            return visitEffectDeclaration((FirEffectDeclaration) firElement, ctx);
+        } else if (firElement instanceof FirField) {
+            return visitField((FirField) firElement, ctx);
+        } else if (firElement instanceof FirFunction) {
+            return visitFunction((FirFunction) firElement, ctx);
+        } else if (firElement instanceof FirImplicitTypeRef) {
+            return visitImplicitTypeRef((FirImplicitTypeRef) firElement, ctx);
+        } else if (firElement instanceof FirIntersectionTypeRef) {
+            return visitIntersectionTypeRef((FirIntersectionTypeRef) firElement, ctx);
+        } else if (firElement instanceof FirLoopJump) {
+            return visitLoopJump((FirLoopJump) firElement, ctx);
+        } else if (firElement instanceof FirJump) {
+            return visitJump((FirJump<? extends FirTargetElement>) firElement, ctx);
+        } else if (firElement instanceof FirNamedReference) {
+            return visitNamedReference((FirNamedReference) firElement, ctx);
+        } else if (firElement instanceof FirPlaceholderProjection) {
+            return visitPlaceholderProjection((FirPlaceholderProjection) firElement, ctx);
+        } else if (firElement instanceof FirThisReference) {
+            return visitThisReference((FirThisReference) firElement, ctx);
+        } else if (firElement instanceof FirReference) {
+            return visitReference((FirReference) firElement, ctx);
+        } else if (firElement instanceof FirResolvable) {
+            return visitResolvable((FirResolvable) firElement, ctx);
+        } else if (firElement instanceof FirResolvedImport) {
+            return visitResolvedImport((FirResolvedImport) firElement, ctx);
+        } else if (firElement instanceof FirResolvedReifiedParameterReference) {
+            return visitResolvedReifiedParameterReference((FirResolvedReifiedParameterReference) firElement, ctx);
+        } else if (firElement instanceof FirSmartCastExpression) {
+            return visitSmartCastExpression((FirSmartCastExpression) firElement, ctx);
+        } else if (firElement instanceof FirSpreadArgumentExpression) {
+            return visitSpreadArgumentExpression((FirSpreadArgumentExpression) firElement, ctx);
+        } else if (firElement instanceof FirTypeRefWithNullability) {
+            return visitTypeRefWithNullability((FirTypeRefWithNullability) firElement, ctx);
+        } else if (firElement instanceof FirTypeRef) {
+            return visitTypeRef((FirTypeRef) firElement, ctx);
+        } else if (firElement instanceof FirThrowExpression) {
+            return visitThrowExpression((FirThrowExpression) firElement, ctx);
+        } else if (firElement instanceof FirTypeParameterRef) {
+            return visitTypeParameterRef((FirTypeParameterRef) firElement, ctx);
+        } else if (firElement instanceof FirTypeParametersOwner) {
+            return visitTypeParametersOwner((FirTypeParametersOwner) firElement, ctx);
+        } else if (firElement instanceof FirTypeProjection) {
+            return visitTypeProjection((FirTypeProjection) firElement, ctx);
+        } else if (firElement instanceof FirVarargArgumentsExpression) {
+            return visitVarargArgumentsExpression((FirVarargArgumentsExpression) firElement, ctx);
+        } else if (firElement instanceof FirWrappedArgumentExpression) {
+            return visitWrappedArgumentExpression((FirWrappedArgumentExpression) firElement, ctx);
+        } else if (firElement instanceof FirWrappedExpression) {
+            return visitWrappedExpression((FirWrappedExpression) firElement, ctx);
+        }
+
+        // Visits to parent classes that should not occur.
+        else if (firElement instanceof FirAnnotation) {
+            return visitAnnotation((FirAnnotation) firElement, ctx);
+        } else if (firElement instanceof FirExpression) {
+            return visitExpression((FirExpression) firElement, ctx);
+        } else if (firElement instanceof FirVariable) {
+            return visitVariable((FirVariable) firElement, ctx);
+        } else if (firElement instanceof FirCallableDeclaration) {
+            return visitCallableDeclaration((FirCallableDeclaration) firElement, ctx);
+        } else if (firElement instanceof FirMemberDeclaration) {
+            return visitMemberDeclaration((FirMemberDeclaration) firElement, ctx);
+        } else if (firElement instanceof FirTypeParameterRefsOwner) {
+            return visitTypeParameterRefsOwner((FirTypeParameterRefsOwner) firElement, ctx);
+        } else if (firElement instanceof FirLoop) {
+            return visitLoop((FirLoop) firElement, ctx);
+        } else if (firElement instanceof FirTargetElement) {
+            return visitTargetElement((FirTargetElement) firElement, ctx);
+        } else if (firElement instanceof FirDeclaration) {
+            return visitDeclaration((FirDeclaration) firElement, ctx);
+        } else if (firElement instanceof FirStatement) {
+            return visitStatement((FirStatement) firElement, ctx);
+        } else if (firElement instanceof FirAnnotationContainer) {
+            return visitAnnotationContainer((FirAnnotationContainer) firElement, ctx);
+        } else if (firElement instanceof FirDiagnosticHolder) {
+            return visitDiagnosticHolder((FirDiagnosticHolder) firElement, ctx);
         }
 
         throw new IllegalArgumentException("Unsupported FirElement.");

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParsingException.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParsingException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.internal;
+
+public class KotlinParsingException extends RuntimeException {
+    public KotlinParsingException(String message, Throwable t) {
+        super(message, t);
+    }
+}


### PR DESCRIPTION
Changes:
- KotlinTypeMapping and KotlinSignatureBuilder will not throw an exception when an unimplemented FIR type or ConeClassType is encountered.
    - This change means KotlinParsingExceptions will be limited to parse failures.
- Parsing exceptions will be thrown in specific visits instead of visitElement to provide insight into the types causing the errors.
- KotlinParser will throw exceptions for unimplemented FIR types with a snippet from the source code to provide insight into where the parsing exception happened in the `SourceFile`.
- Covered various potential NPEs.

fixes #37