### PR TITLE
Add two failing tests for ChangeType

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -58,6 +58,66 @@ public class ChangeTypeTest implements RewriteTest {
     }
 
     @Test
+    void changeTypeWithGenericArgument() {
+        rewriteRun(
+          kotlin(
+            """
+            package a.b
+            class Original<A>
+            """),
+          kotlin(
+            """
+            package x.y
+            class Target<A>
+            """),
+          kotlin(
+            """
+            package example
+            
+            import a.b.Original
+            
+            fun test(original: Original<String>) { }
+            """,
+            """
+            package example
+            
+            import x.y.Target
+            
+            fun test(original: Target<String>) { }
+            """
+          )
+        );
+    }
+
+    @Test
+    void changeTypeWithGenericArgumentFullyQualified() {
+        rewriteRun(
+          kotlin(
+            """
+            package a.b
+            class Original<A>
+            """),
+          kotlin(
+            """
+            package x.y
+            class Target<A>
+            """),
+          kotlin(
+            """
+            package example
+            
+            fun test(original: a.b.Original<String>) { }
+            """,
+            """
+            package example
+                        
+            fun test(original: x.y.Target<String>) { }
+            """
+          )
+        );
+    }
+
+    @Test
     void changeType() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
This PR adds two test cases that are currently failing for `ChangeType` when the type has type arguments.

- `changeTypeWithGenericArgument` fails to replace the parameter in the function and only replaces the import
- `changeTypeWithGenericArgumentFullyQualified` adds an unnecessary import, which doesn't seem to be the case of the `changeType` test.