### PR TITLE
AddImport not working for Kotlin

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -1,0 +1,32 @@
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.tree.ParserAssertions.kotlin;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+public class AddImportTest  implements RewriteTest {
+    @Test
+    void addImportBeforeImportWithSameInsertIndex() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("org.junit.jupiter.api.Assertions", "assertFalse", false))),
+          kotlin(
+            """
+              import org.junit.jupiter.api.Assertions.assertTrue
+              import org.junit.Test
+
+              class MyTest
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertFalse
+              import org.junit.jupiter.api.Assertions.assertTrue
+              import org.junit.Test
+
+              class MyTest
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
`AddImport` seems to only work for Java, and this PR adds a failing test case ported from [OpenRewrite/Rewrite - AddImportTest](https://github.com/openrewrite/rewrite/blob/main/rewrite-java-test/src/test/java/org/openrewrite/java/AddImportTest.java).

I encountered this when trying to accomplish the following in https://github.com/nomisRev/rewrite-arrow/pull/3:
 - `EffectScope` is an `interface` with a _method_ `ensure`.
 - `Raise` is an `interface` with a _top-level extension_ `ensure`.
 - After executing `ChangeType` from `EffectScope` to `Raise` the `ensure` import needs to be added.

```java
kotlin(
  """
    package com.yourorg
          
    import arrow.core.continuations.EffectScope

    suspend fun EffectScope<Int>.test(): Unit =
      ensure(false) { -1 }
    """,
  """
    package com.yourorg
          
    import arrow.core.raise.Raise
    import arrow.core.raise.ensure

    suspend fun Raise<Int>.test(): Unit =
      ensure(false) { -1 }
    """
)
```