### PR TITLE
MethodMatcher seems to have broken in 0.3.0

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/MethodMatcherTest.java
+++ b/src/test/java/org/openrewrite/kotlin/MethodMatcherTest.java
@@ -1,0 +1,25 @@
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.search.FindMethods;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+public class MethodMatcherTest implements RewriteTest {
+
+    @Test
+    void matchesTopLevelFunction() {
+        rewriteRun(
+          kotlin(
+            """
+              class File
+              
+              fun function() {}
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(FindMethods.find(cu, "FileKt function()")).isNotEmpty())
+          )
+        );
+    }
+}


### PR DESCRIPTION
When trying to bump to `0.3.0` I encountered 3 issues:

 - Binary breaking change in `UsesMethod`. I guess this is non-problematic for "experimental" library such as rewrite-kotlin, but was unexpected without a major bump in rewrite version.
 - BOM is outdated, but this was easily fixed by explicitly relying on versions
 - Regression in MethodMatcher, I suspect only for rewrite-kotlin

I am not 100% sure, but I think this test reproduces the problem.