### PR TITLE
Parser error: init block test

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -274,4 +274,11 @@ class ClassDeclarationTest implements RewriteTest {
             """)
         );
     }
+
+    @Test
+    void valueClass() {
+        rewriteRun(
+          kotlin("@JvmInline value class Wrapper(val int: Int)")
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -268,7 +268,7 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin("""
             class Test {
                 init {
-                    println("Hello, world!")
+                    println( "Hello, world!" )
                 }
             }
             """)
@@ -278,7 +278,7 @@ class ClassDeclarationTest implements RewriteTest {
     @Test
     void valueClass() {
         rewriteRun(
-          kotlin("@JvmInline value class Wrapper(val int: Int)")
+          kotlin("@JvmInline value class Wrapper ( val int : Int )")
         );
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -259,4 +259,17 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin("interface B < out R >")
         );
     }
+
+    @Test
+    void init() {
+        rewriteRun(
+          kotlin("""
+            class Test {
+                init {
+                    println("Hello, world!")
+                }
+            }
+            """)
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.kotlin.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -213,7 +213,7 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
-    @Disabled
+    @ExpectedToFail
     @Test
     void multipleBounds() {
         rewriteRun(
@@ -260,7 +260,9 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/68")
     @Test
+    @ExpectedToFail
     void init() {
         rewriteRun(
           kotlin("""


### PR DESCRIPTION
Adds a test for issue https://github.com/openrewrite/rewrite-kotlin/issues/68 that shows parsing fails on a class init block.

It also adds a second test that was missing checking `value class`, adding for completeness.