### PR TITLE
Parsers tests for lambda modifiers

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
@@ -219,9 +219,9 @@ class MethodDeclarationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """          
-            inline fun example(
-              crossinline block: () -> Unit
-            ): Unit = Unit
+            inline fun example (
+              crossinline block : ( ) -> Unit
+            ) : Unit = Unit
             """)
         );
     }
@@ -233,9 +233,9 @@ class MethodDeclarationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """          
-            inline fun example(
-              noinline block: () -> Unit
-            ): Unit = Unit
+            inline fun example (
+              noinline block : ( ) -> Unit
+            ) : Unit = Unit
             """)
         );
     }

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -208,6 +209,34 @@ class MethodDeclarationTest implements RewriteTest {
             ) : String = TODO()
             """
           )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/70")
+    @Test
+    @ExpectedToFail
+    void crossinline() {
+        rewriteRun(
+          kotlin(
+            """          
+            inline fun example(
+              crossinline block: () -> Unit
+            ): Unit = Unit
+            """)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/70")
+    @Test
+    @ExpectedToFail
+    void noinline() {
+        rewriteRun(
+          kotlin(
+            """          
+            inline fun example(
+              noinline block: () -> Unit
+            ): Unit = Unit
+            """)
         );
     }
 }


### PR DESCRIPTION
Adds two test cases for issue https://github.com/openrewrite/rewrite-kotlin/issues/70 for parsing issue of lambda modifiers.