### PR TITLE
Parser tests for sealed properties

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -261,45 +261,19 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
-    @Test
-    void sealedClass() {
-        rewriteRun(
-          kotlin(
-            """
-            sealed class DomainError
-            data class EmptyUpdate(val description: String) : DomainError()
-            object PasswordNotMatched : DomainError()
-            """
-          )
-        );
-    }
-
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/72")
     @Test
+    @ExpectedToFail
     void sealedClassWithPropertiesAndDataClass() {
         rewriteRun(
           kotlin(
             """
             sealed class InvalidField {
-              val errors: List<String>
               val field: String
             }
-            data class InvalidEmail(override val errors: List<String>) : InvalidField() {
+            data class InvalidEmail(val errors: List<String>) : InvalidField() {
               override val field: String = "email"
             }
-            """
-          )
-        );
-    }
-
-    @Test
-    void sealedInterface() {
-        rewriteRun(
-          kotlin(
-            """
-            sealed interface DomainError
-            data class EmptyUpdate(val description: String) : DomainError
-            object PasswordNotMatched : DomainError
             """
           )
         );
@@ -313,10 +287,9 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
             sealed interface InvalidField {
-              val errors: List<String>
               val field: String
             }
-            data class InvalidEmail(override val errors: List<String>) : InvalidField {
+            data class InvalidEmail : InvalidField {
               override val field: String = "email"
             }
             """
@@ -330,11 +303,9 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
             sealed interface InvalidField {
-              val errors: List<String>
               val field: String
             }
             object InvalidEmail : InvalidField {
-              override val errors: List<String> = emptyList()
               override val field: String = "email"
             }
             """

--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -271,8 +271,8 @@ class ClassDeclarationTest implements RewriteTest {
             sealed class InvalidField {
               val field: String
             }
-            data class InvalidEmail(val errors: List<String>) : InvalidField() {
-              override val field: String = "email"
+            data class InvalidEmail( val errors : List<String> ) : InvalidField ( ) {
+              override val field : String = "email"
             }
             """
           )
@@ -287,10 +287,10 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
             sealed interface InvalidField {
-              val field: String
+              val field : String
             }
-            data class InvalidEmail : InvalidField {
-              override val field: String = "email"
+            data class InvalidEmail( val errors : List<String> ) : InvalidField {
+              override val field : String = "email"
             }
             """
           )
@@ -303,10 +303,10 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
             sealed interface InvalidField {
-              val field: String
+              val field : String
             }
             object InvalidEmail : InvalidField {
-              override val field: String = "email"
+              override val field : String = "email"
             }
             """
           )


### PR DESCRIPTION
Adds a couple tests for sealed class / interface, and two failing test-cases related to https://github.com/openrewrite/rewrite-kotlin/issues/72 that show the failing parser error when the sealed class/interface have properties that get implemented by a data class, **but not in the constructor**.

If they're implemented by the constructor it works fine, but I didn't add a test-case for this.