### PR TITLE
Parser test class secondary constructor

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -179,13 +180,15 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/74")
     @Test
+    @ExpectedToFail
     void secondaryConstructor() {
         rewriteRun(
           kotlin(
             """
-            class Test {
-                constructor ( val answer : Int )
+            class Test ( val answer : Int ) {
+                constructor ( ) : this ( 42 )
             }
             """
           )


### PR DESCRIPTION
Adds test for issue https://github.com/openrewrite/rewrite-kotlin/issues/74

The original test for secondary constructor was incorrect.

You can define a Kotlin constructor _short-hand_ in the class definition *or* in the class body. If you define a constructor in the body, it *does not* create a no-arg constructor.

So the existing `secondaryConstructor` test was incorrect, and resulting in a false positive.