### PR TITLE
Various parsing fixes.

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
@@ -38,6 +38,76 @@ class BinaryTest implements RewriteTest {
     }
 
     @Test
+    void notEquals() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method ( ) {
+              val n = 0
+              val b = n != 0
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void greaterThan() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method ( ) {
+              val n = 0
+              val b = n > 0
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void greaterThanOrEqual() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method ( ) {
+              val n = 0
+              val b = n >= 0
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void lessThan() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method ( ) {
+              val n = 0
+              val b = n < 0
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void lessThanOrEqual() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method ( ) {
+              val n = 0
+              val b = n <= 0
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void endOfLineBreaks() {
         rewriteRun(
           kotlin(
@@ -185,6 +255,20 @@ class BinaryTest implements RewriteTest {
             fun method ( ) {
               val n = 0
               val b = n == ( 1 - 1 )
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void rem() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method ( ) {
+              val n = 0
+              val b = n % 2 == 0
             }
             """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -91,6 +92,34 @@ class LambdaTest implements RewriteTest {
             """
             fun method ( ) {
                 val lambda: suspend ( Int ) -> Int = { number : Int -> number * number }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void ignored() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method() {
+                val list = listOf(1, 2, 3)
+                list.filterIndexed { index, ignored -> index % 2 == 0 }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void underscore() {
+        rewriteRun(
+          kotlin(
+            """
+            fun method() {
+                val list = listOf(1, 2, 3)
+                list.filterIndexed { index, _ -> index % 2 == 0 }
             }
             """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
@@ -427,4 +427,30 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void errorNameRefOnSelect() {
+        rewriteRun(
+          kotlin(
+            """
+            fun test() {
+              "foo".foo()
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void errorNameRefOnSelectWithReference() {
+        rewriteRun(
+          kotlin(
+            """
+            fun test(bar: String) {
+              "foo $bar".foo()
+            }
+            """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -234,7 +234,7 @@ class VariableDeclarationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/58")
     @Test
-    void destructuringVariableDecleration() {
+    void destructuringVariableDeclaration() {
         rewriteRun(
           kotlin(
             """


### PR DESCRIPTION
Changes:
- Prevent NPE checking from checking for compiler-generated fake sources when the source is null.
- Use text from LightSource on error name references when a `KtRealSource` is unavailable. fixes #91 
- Fixed J.Binary type assigned for `<=`.
- Added support for rem operator.
- Added support for unique name generated by the compiler for `_` in lambda.
- Pre-calculate the implicit destruct values to skip compiler-generated properties.

fixes #88