### PR TITLE
Basic support for platform-typed objects

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
@@ -156,7 +156,12 @@ public class KotlinTypeMapping implements JavaTypeMapping<Object> {
         if (classType instanceof FirResolvedTypeRef) {
             // The resolvedTypeRef is used to create parameterized types.
             resolvedTypeRef = (FirResolvedTypeRef) classType;
-            FirRegularClassSymbol symbol = TypeUtilsKt.toRegularClassSymbol(resolvedTypeRef.getType(), firSession);
+            ConeKotlinType type = resolvedTypeRef.getType();
+            if (type instanceof ConeFlexibleType) {
+                // for platform types the lower bound is the nullable type
+                type = ((ConeFlexibleType) type).getLowerBound();
+            }
+            FirRegularClassSymbol symbol = TypeUtilsKt.toRegularClassSymbol(type, firSession);
             if (symbol == null) {
                 typeCache.put(signature, JavaType.Unknown.getInstance());
                 return JavaType.Unknown.getInstance();


### PR DESCRIPTION
So that the type which is derived from a platform type doesn't end up as `Unknown`, the corresponding lower bound is used instead (for a platform type `String!` the lower bound is `String` and the upper bound is `String?`).