### PR TITLE
Fix NPE when failed to parse Kotlin file

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -185,7 +185,8 @@ public class KotlinParser implements Parser<K.CompilationUnit> {
                         ctx.getOnError().accept(t);
                     }
                     return null;
-                });
+                })
+                .filter(Objects::nonNull);
     }
 
     /**


### PR DESCRIPTION
https://rewriteoss.slack.com/archives/C01A843MWG5/p1685730878072759

We are getting this error when project has Kotlin files

```
Caused by: java.lang.NullPointerException: Cannot invoke "org.openrewrite.kotlin.tree.K$CompilationUnit.getSourcePath()" because "cu" is null
        at org.openrewrite.gradle.isolated.DefaultProjectParser.lambda$parse$9(DefaultProjectParser.java:733)
```

From @timtebeek `.filter(Objects::nonNull)` exist in GroovyParser, also in several other parser implementations like yaml, properties, etc. Looks like just missing from KotlinParser