### PR TITLE
Added support for parsing error analysis.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     implementation(platform("org.openrewrite:rewrite-bom:${latest}"))
     implementation("org.openrewrite:rewrite-java")
+    implementation("org.openrewrite.recipe:rewrite-all:${latest}")
 
     implementation(platform(kotlin("bom", kotlinVersion)))
     implementation(kotlin("compiler-embeddable"))

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodReferenceTest.java
@@ -59,7 +59,7 @@ class MethodReferenceTest implements RewriteTest {
           kotlin(
             """
             fun method() {
-                listOf(1, 2, 3).map(::println)
+                listOf ( 1 , 2 , 3 ) . map ( :: println )
             }
             """
           )


### PR DESCRIPTION
Changes
- Parsing exceptions will be converted to a `J.Unknown` whenever possible while preserving the source code.

fixes #115