### PR TITLE
Fixed printing of java static imports, revised printing Kotlin inline…

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -4125,7 +4125,8 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
     private List<J.Annotation> mapModifiers(List<FirAnnotation> firAnnotations, String stopWord) {
         if ("<no name provided>".equals(stopWord)) {
-            return mapAnnotations(firAnnotations);
+            List<J.Annotation> annotations = mapAnnotations(firAnnotations);
+            return annotations == null ? emptyList() : annotations;
         }
 
         List<FirAnnotation> findMatch = new ArrayList<>(firAnnotations.size());

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -454,21 +454,9 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         public J visitImport(J.Import import_, PrintOutputCapture<P> p) {
             beforeSyntax(import_, Space.Location.IMPORT_PREFIX, p);
             p.append("import");
-            if (import_.isStatic()) {
-                J.FieldAccess qualid = import_.getQualid();
-                visitSpace(qualid.getPrefix(), Space.Location.FIELD_ACCESS_PREFIX, p);
-                if (qualid.getTarget() instanceof J.FieldAccess) {
-                    visit(((J.FieldAccess) qualid.getTarget()).getTarget(), p);
-                    p.append(".");
-                } else {
-                    visit(qualid.getTarget(), p);
-                }
-                visit(qualid.getName(), p);
-            } else {
-                visit(import_.getQualid(), p);
-            }
+            visit(import_.getQualid(), p);
             JLeftPadded<J.Identifier> alias = import_.getPadding().getAlias();
-            if(alias != null) {
+            if (alias != null) {
                 visitSpace(alias.getBefore(), Space.Location.IMPORT_ALIAS_PREFIX, p);
                 p.append("as");
                 visit(alias.getElement(), p);

--- a/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.java.AddImport;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -65,21 +66,13 @@ public class AddImportTest implements RewriteTest {
     }
 
     @Test
-    void addStaticImport() {
+    void addInlineImport() {
         rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new AddImport<>("a.b.Target", "method", false))),
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("a.b.method", null, false))),
           kotlin(
             """
               package a.b
               class Original
-              """
-          ),
-          kotlin(
-            """
-              package a.b
-              class Target {
-                  inline fun method() {}
-              }
               """
           ),
           kotlin(
@@ -92,12 +85,29 @@ public class AddImportTest implements RewriteTest {
               """,
             """
               import a.b.Original
-              
               import a.b.method
               
               class A {
                   val type : Original = Original()
               }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/114")
+    @Test
+    void addJavaStaticImport() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new AddImport<>("org.junit.jupiter.api.Assertions", "assertFalse", false))),
+          kotlin(
+            """
+              class Foo
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertFalse
+              
+              class Foo
               """
           )
         );


### PR DESCRIPTION
Changes:
- Revised printing imports of Kotlin inline declarations.
- Revised printing static imports to support importing static java fields/methods.

fixes #54 #114