### PR TITLE
Added support to parse Kotlin's set function call.

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/MapEntryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MapEntryTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
@@ -29,6 +30,21 @@ class MapEntryTest implements RewriteTest {
             """
               val a = mapOf ( 1 to "one" , 2 to "two" )
               val b = a [ 1 ]
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/136")
+    @Test
+    void mapSetFunctionCall() {
+        rewriteRun(
+          kotlin(
+            """
+              fun foo() {
+                  val a = mutableMapOf ( 1 to "one" , 2 to "two" )
+                  a [ 1 ] = "three"
+              }
               """
           )
         );


### PR DESCRIPTION
Changes:

- Added support for Kotlin's implicit set function call.
    - Indexed key access on maps will parse correctly. The indexed access is converted to a `J.ArrayAccess`, and the assignment is converted to a `J.Assignment`.
- Updated Kotlin's implicit get function call to return a `J.ArrayAccess` instead of a `K.Binary`.

fixes #136