### PR TITLE
Fix ExtensionFunction parsing error

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1146,8 +1146,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             receiver = ((FirCheckedSafeCallSubject) firElement).getOriginalReceiverRef().getValue();
         } else if (firElement instanceof FirThisReceiverExpression) {
             receiver = firElement;
-        }
-        else if (!(firElement instanceof FirNoReceiverExpression)) {
+        } else if (!(firElement instanceof FirNoReceiverExpression)) {
             receiver = firElement;
         }
 

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1137,15 +1137,17 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
     @Nullable
     private FirElement getReceiver(@Nullable FirElement firElement) {
-        if (firElement == null) {
+        if (firElement == null || firElement.getSource() == null) {
             return null;
         }
 
         FirElement receiver = null;
         if (firElement instanceof FirCheckedSafeCallSubject) {
             receiver = ((FirCheckedSafeCallSubject) firElement).getOriginalReceiverRef().getValue();
-        } else if (!(firElement instanceof FirNoReceiverExpression ||
-                firElement instanceof FirThisReceiverExpression)) {
+        } else if (firElement instanceof FirThisReceiverExpression) {
+            receiver = firElement;
+        }
+        else if (!(firElement instanceof FirNoReceiverExpression)) {
             receiver = firElement;
         }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/ExtensionFunctionTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ExtensionFunctionTest.java
@@ -15,21 +15,18 @@
  */
 package org.openrewrite.kotlin.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class ExtensionFunctionTest implements RewriteTest {
-
-    @Disabled
     @Test
     void extensionFunction() {
         rewriteRun(
           kotlin(
             """
-              fun String . escape ( ) = this . replace ( "a" , "b" )"
+              fun String . escape ( ) = this . replace ( "a" , "b" )
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/ExtensionFunctionTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ExtensionFunctionTest.java
@@ -16,17 +16,21 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class ExtensionFunctionTest implements RewriteTest {
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/129")
     @Test
     void extensionFunction() {
         rewriteRun(
           kotlin(
             """
               fun String . escape ( ) = this . replace ( "a" , "b" )
+              fun String . escape2 ( ) =  replace ( "a" , "b" )
               """
           )
         );


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-kotlin/issues/129 

This PR is to fix `ExtensionFunction` with `this` as an explicit receiver parsing error.

Here is an example:
```kotlin
fun String . escape ( ) = this . replace ( "a" , "b" )
```

Error is:

Expected no change, but got 
```diff
---fun String . escape ( ) = this . replace ( "a" , "b" )
+++fun String . escape ( ) = replacethis . replace ( "a") , "b" )
```


