### PR TITLE
Detect FIR unary operator elements in visitComparisonExpression

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -271,6 +273,26 @@ class BinaryTest implements RewriteTest {
                 val b = n % 2 == 0
               }
               """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/139")
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "-- n",
+      "n --"
+    })
+    void unaryOp(String op) {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( ) {
+                var n = 0
+                val a = %s == -1
+                val b = -1 == %s
+              }
+              """.formatted(op, op)
           )
         );
     }

--- a/src/test/java/org/openrewrite/kotlin/tree/WhileLoopTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/WhileLoopTest.java
@@ -16,6 +16,9 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
@@ -45,6 +48,28 @@ class WhileLoopTest implements RewriteTest {
                   while ( true ) test ( )
               }
               """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/139")
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "-- len",
+      "len --"
+    })
+    void unaryOp(String op) {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  val len = 10
+                  while (%s > 0) {
+                  }
+                  while (0 < %s) {
+                  }
+              }
+              """.formatted(op, op)
           )
         );
     }


### PR DESCRIPTION
Changes:

- Fixes parsing unary operators in comparison and binary expressions.

fixes #139