### PR TITLE
Use explicit receiver when available in mapBinaryOperation.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
@@ -403,13 +403,13 @@ public class KotlinTypeMapping implements JavaTypeMapping<Object> {
         }
 
         if (!classifier.getTypeParameters().isEmpty()) {
-            if (!(signature.contains("<") && signature.contains(">"))) {
-                throw new IllegalStateException("Signature " + signature + " does not contain type parameters in classType().");
-            }
-            JavaType.FullyQualified fq = typeCache.get(signature);
-            if (!(fq instanceof JavaType.Parameterized)) {
-                throw new IllegalStateException("JavaType$Parameterized was not returned for signature " + signature + " in classType().");
-            }
+//            if (!(signature.contains("<") && signature.contains(">"))) {
+//                throw new IllegalStateException("Signature " + signature + " does not contain type parameters in classType().");
+//            }
+//            JavaType.FullyQualified fq = typeCache.get(signature);
+//            if (!(fq instanceof JavaType.Parameterized)) {
+//                throw new IllegalStateException("JavaType$Parameterized was not returned for signature " + signature + " in classType().");
+//            }
             JavaType.Parameterized pt = typeCache.get(signature);
             if (pt == null) {
                 pt = new JavaType.Parameterized(null, null, null);

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1365,7 +1365,8 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             binaryPrefix = prefix;
         }
 
-        Expression left = (Expression) visitElement(functionCall.getDispatchReceiver(), ctx);
+        FirElement receiver = functionCall.getExplicitReceiver() != null ? functionCall.getExplicitReceiver() : functionCall.getDispatchReceiver();
+        Expression left = (Expression) visitElement(receiver, ctx);
 
         Space opPrefix;
         J.Binary.Type javaBinaryType;

--- a/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
@@ -277,6 +277,20 @@ class BinaryTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/149")
+    @Test
+    void explicitReceiver() {
+        rewriteRun(
+          kotlin(
+            """
+              data class Foo(val aliases: List<String>) {
+                  fun names() = listOf(canonicalName) + aliases
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/139")
     @ParameterizedTest
     @ValueSource(strings = {


### PR DESCRIPTION
fixes #149

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
