### PR TITLE
Add recipe ImplicitParameterInLambda

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/recipe/ImplicitParameterInLambda.java
+++ b/src/main/java/org/openrewrite/kotlin/recipe/ImplicitParameterInLambda.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.recipe;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.KotlinVisitor;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
+
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ImplicitParameterInLambda extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "\"it\" shouldn't be used as a lambda parameter name";
+    }
+
+    @Override
+    public String getDescription() {
+        return "\"it\" is a special identifier that allows you to refer to the current parameter being passed to a " +
+               "lambda expression without explicitly naming the parameter." +
+               "Lambda expressions are a concise way of writing anonymous functions. Many lambda expressions have " +
+               "only one parameter, when this is true the compiler can determine the parameter type by context. Thus " +
+               "when using it with single parameter lambda expressions, you do not need to declare the type.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(2);
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("RSPEC-6558");
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new KotlinVisitor<ExecutionContext>() {
+            @Override
+            public J visitLambda(J.Lambda lambda, ExecutionContext executionContext) {
+                lambda = (J.Lambda) super.visitLambda(lambda, executionContext);
+                if (isParameterExplicitIt(lambda)) {
+                    lambda = lambda.withParameters(lambda.getParameters().withParameters(new ArrayList<>()));
+                }
+                return lambda;
+            }
+        };
+    }
+
+    /**
+     * Return ture when the lambda has only one parameter `it` and with no type.
+     */
+    private static boolean isParameterExplicitIt(J.Lambda lambda) {
+        J.Lambda.Parameters parameters = lambda.getParameters();
+        if (parameters.getParameters().size() != 1) {
+            return false;
+        }
+
+        J parameter = parameters.getParameters().get(0);
+        if (parameter instanceof J.VariableDeclarations) {
+            J.VariableDeclarations vs = (J.VariableDeclarations) parameter;
+            if (vs.getVariables().size() != 1 || vs.getTypeExpression() != null) {
+                return false;
+            }
+
+            J.VariableDeclarations.NamedVariable v = vs.getVariables().get(0);
+            if (v.getSimpleName().equals("it")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/org/openrewrite/kotlin/recipe/ImplicitParameterInLambdaTest.java
+++ b/src/test/java/org/openrewrite/kotlin/recipe/ImplicitParameterInLambdaTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.recipe;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class ImplicitParameterInLambdaTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ImplicitParameterInLambda());
+    }
+
+    @DocumentExample
+    @Test
+    void removeIt() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  listOf(1, 2, 3).forEach { it -> it.and(6) }
+                  val a: (Int) -> Int = { it -> it + 5 }
+              }
+              """,
+            """
+              fun method() {
+                  listOf(1, 2, 3).forEach { it.and(6) }
+                  val a: (Int) -> Int = { it + 5 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithType() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  val d = {it: Int -> it + 5 } // Compliant, need to know the type
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeIfAlreadyImplicit() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  listOf(1, 2, 3).forEach { it.and(6) }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithMultiParameters() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  listOf(1, 2, 3).forEachIndexed { it, index ->
+                      val result = it * index
+                      println(result)
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/kotlin/recipe/ReplaceCharToIntWithCodeTest.java
+++ b/src/test/java/org/openrewrite/kotlin/recipe/ReplaceCharToIntWithCodeTest.java
@@ -31,7 +31,7 @@ public class ReplaceCharToIntWithCodeTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void kotlinFile() {
+    void replace() {
         rewriteRun(
           kotlin(
             """


### PR DESCRIPTION
Add recipe `ImplicitParameterInLambda` to remove `It` if it's the only parameter of a lambda.
Sonar Rule: https://rules.sonarsource.com/kotlin/RSPEC-6558

Example
```kotlin
listOf(1, 2, 3).forEach { it -> it.and(6) } // Noncompliant
listOf(1, 2, 3).forEach { it.and(6) } // Compliant
```