### PR TITLE
Add `EqualsMethodUsage` recipe

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/recipe/EqualsMethodUsage.java
+++ b/src/main/java/org/openrewrite/kotlin/recipe/EqualsMethodUsage.java
@@ -1,0 +1,98 @@
+package org.openrewrite.kotlin.recipe;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.KotlinVisitor;
+import org.openrewrite.kotlin.tree.K;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class EqualsMethodUsage extends Recipe {
+    private static J.Binary equalsBinaryTemplate = null;
+
+    @Override
+    public String getDisplayName() {
+        return "Structural equality tests should use \"==\" or \"!=\"";
+    }
+
+    @Override
+    public String getDescription() {
+        return "In Kotlin, == means structural equality and != structural inequality and both map to the left-side " +
+               "term’s equals() function. It is, therefore, redundant to call equals() as a function. Also, == and !=" +
+               " are more general than equals() and !equals() because it allows either of both operands to be null.\n" +
+               "Developers using equals() instead of == or != is often the result of adapting styles from other " +
+               "languages like Java, where == means reference equality and != means reference inequality.\n" +
+               "The == and != operators are a more concise and elegant way to test structural equality than calling a function.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("RSPEC-6519");
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(3);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new KotlinVisitor<ExecutionContext>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method,
+                                           ExecutionContext executionContext) {
+                method = (J.MethodInvocation) super.visitMethodInvocation(method, executionContext);
+                if ("equals".equals(method.getSimpleName()) &&
+                    method.getArguments().size() == 1 &&
+                    TypeUtils.isOfClassType(method.getMethodType().getReturnType(), "kotlin.Boolean") &&
+                    method.getSelect() != null
+                ) {
+                    Expression lhs = method.getSelect();
+                    Expression rhs = method.getArguments().get(0);
+                    return buildEqualsBinary(lhs, rhs);
+                }
+                return method;
+            }
+        };
+    }
+
+    @SuppressWarnings("all")
+    private static J.Binary buildEqualsBinary(Expression left, Expression right) {
+        if (equalsBinaryTemplate == null) {
+            K.CompilationUnit kcu = KotlinParser.builder().build()
+                .parse("fun method(a : String, b : String) {val isSame = a == b}")
+                .map(K.CompilationUnit.class::cast)
+                .findFirst()
+                .get();
+
+            equalsBinaryTemplate = new KotlinVisitor<AtomicReference<J.Binary>>() {
+                @Override
+                public J visitBinary(J.Binary binary, AtomicReference<J.Binary> target) {
+                    target.set(binary);
+                    return binary;
+                }
+            }.reduce(kcu, new AtomicReference<J.Binary>()).get();
+        }
+
+        Space rhsPrefix = right.getPrefix();
+        if (rhsPrefix.getWhitespace().isEmpty()) {
+            rhsPrefix = rhsPrefix.withWhitespace(" ");
+        }
+        return equalsBinaryTemplate.withLeft(left.withPrefix(left.getPrefix())).withRight(right.withPrefix(rhsPrefix));
+    }
+
+}

--- a/src/test/java/org/openrewrite/kotlin/recipe/EqualsMethodUsageTest.java
+++ b/src/test/java/org/openrewrite/kotlin/recipe/EqualsMethodUsageTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.kotlin.recipe;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -60,6 +61,61 @@ class EqualsMethodUsageTest implements RewriteTest {
             """
               fun isSame(obj1 : String, obj2: String) : Boolean {
                   val isSame = obj1 == /*comment*/ obj2
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceWithNotEqual() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method(obj1 : String, obj2: String) {
+                  val isNotSame = !obj1.equals(obj2)
+              }
+              """,
+            """
+              fun method(obj1 : String, obj2: String) {
+                  val isNotSame = obj1 != obj2
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceWithNotEqualWithComments() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method(obj1 : String, obj2: String) {
+                  val isNotSame = !obj1.equals( /*comment*/ obj2)
+              }
+              """,
+            """
+              fun method(obj1 : String, obj2: String) {
+                  val isNotSame = obj1 != /*comment*/ obj2
+              }
+              """
+          )
+        );
+    }
+
+    @Disabled("Parentheses parsing error to be fixed")
+    @Test
+    void replaceWithNotEqualInParentheses() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method(obj1 : String, obj2: String) {
+                  val isNotSame = !(obj1.equals(obj2))
+              }
+              """,
+            """
+              fun method(obj1 : String, obj2: String) {
+                  val isNotSame = obj1 != obj2
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/recipe/EqualsMethodUsageTest.java
+++ b/src/test/java/org/openrewrite/kotlin/recipe/EqualsMethodUsageTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.recipe;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class EqualsMethodUsageTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new EqualsMethodUsage());
+    }
+
+    @DocumentExample
+    @Test
+    void replace() {
+        rewriteRun(
+          kotlin(
+            """
+              fun isSame(obj1 : String, obj2: String) : Boolean {
+                  val isSame = obj1.equals(obj2)
+              }
+              """,
+            """
+              fun isSame(obj1 : String, obj2: String) : Boolean {
+                  val isSame = obj1 == obj2
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceWithComment() {
+        rewriteRun(
+          kotlin(
+            """
+              fun isSame(obj1 : String, obj2: String) : Boolean {
+                  val isSame = obj1.equals( /*comment*/ obj2)
+              }
+              """,
+            """
+              fun isSame(obj1 : String, obj2: String) : Boolean {
+                  val isSame = obj1 == /*comment*/ obj2
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Add recipe `EqualsMethodUsage` to replace `equals()` with `==`
Structural equality tests should use "==" or "!="

Sonar rule: https://rules.sonarsource.com/kotlin/RSPEC-6519

example: 
```diff
--- val isSame = obj1.equals(obj2)
+++ val isSame = obj1 == obj2
```


