### PR TITLE
Revised `KotlinParserVisitor` to access PSI.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeMapping.java
@@ -66,14 +66,12 @@ public class KotlinTypeMapping implements JavaTypeMapping<Object> {
     private final KotlinTypeSignatureBuilder signatureBuilder;
     private final JavaTypeCache typeCache;
     private final FirSession firSession;
-    private final JavaReflectionTypeMapping reflectionTypeMapping;
 
 
     public KotlinTypeMapping(JavaTypeCache typeCache, FirSession firSession) {
         this.signatureBuilder = new KotlinTypeSignatureBuilder(firSession);
         this.typeCache = typeCache;
         this.firSession = firSession;
-        this.reflectionTypeMapping = new JavaReflectionTypeMapping(typeCache);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/src/main/java/org/openrewrite/kotlin/internal/CompiledSource.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/CompiledSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.kotlin;
+package org.openrewrite.kotlin.internal;
 
 import lombok.Value;
-import org.jetbrains.kotlin.fir.declarations.FirFile;
-import org.openrewrite.Parser;
+import org.jetbrains.kotlin.fir.FirSession;
+
+import java.util.Collection;
 
 @Value
-public class CompiledKotlinSource {
-    Parser.Input input;
-    FirFile firFile;
+public class CompiledSource {
+    FirSession firSession;
+    Collection<KotlinSource> sources;
 }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -87,7 +87,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     private final FirSession firSession;
     private int cursor;
 
-    private final Map<Integer, ASTNode> nodes = new HashMap<>();
+    private Map<Integer, ASTNode> nodes;
 
     // Associate top-level function and property declarations to the file.
     @Nullable
@@ -104,30 +104,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         this.typeMapping = new KotlinTypeMapping(typeCache, firSession);
         this.ctx = ctx;
         this.firSession = firSession;
-        init(kotlinSource.getKtFile());
-    }
-
-    private void init(KtFile ktFile) {
-        PsiElementVisitor v = new PsiElementVisitor() {
-            @Override
-            public void visitElement(@NotNull PsiElement element) {
-                if (!(element instanceof KtFile) && element.getTextLength() != 0) {
-                    // Set the node at the cursor to the last visited element.
-                    nodes.put(element.getTextRange().getStartOffset(), element.getNode());
-                    assert source.substring(element.getTextRange().getStartOffset(), element.getTextRange().getEndOffset()).equals(element.getText());
-                }
-
-                for (PsiElement child : element.getChildren()) {
-                    if (child != null) {
-                        visitElement(child);
-                    }
-                }
-                if (element.getNextSibling() != null) {
-                    visitElement(element.getNextSibling());
-                }
-            }
-        };
-        v.visitElement(ktFile);
+        this.nodes = kotlinSource.getNodes();
     }
 
     @Override
@@ -3698,6 +3675,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                     if (node.getTextRange().getEndOffset() >= firElement.getSource().getEndOffset()) {
                         return wrapInParens(firElement, prefix, ctx);
                     }
+                    break;
                 case "REFERENCE_EXPRESSION":
                     if ("POSTFIX_EXPRESSION".equals(node.getTreeParent().getElementType().getDebugName()) && firElement instanceof FirBlock) {
                         firElement = ((FirBlock) firElement).getStatements().get(1);

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.internal;
+
+import lombok.Setter;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.jetbrains.kotlin.fir.declarations.FirFile;
+import org.jetbrains.kotlin.psi.KtFile;
+import org.openrewrite.Parser;
+
+@Value
+public class KotlinSource {
+    Parser.Input input;
+    KtFile ktFile; // concrete syntax tree
+
+    @Setter
+    @NonFinal
+    FirFile firFile;
+}

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
@@ -15,19 +15,68 @@
  */
 package org.openrewrite.kotlin.internal;
 
+import lombok.Getter;
 import lombok.Setter;
 import lombok.Value;
 import lombok.experimental.NonFinal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode;
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement;
+import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor;
+import org.jetbrains.kotlin.com.intellij.psi.PsiFile;
 import org.jetbrains.kotlin.fir.declarations.FirFile;
 import org.jetbrains.kotlin.psi.KtFile;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Parser;
 
-@Value
+import java.util.*;
+
+@Getter
 public class KotlinSource {
     Parser.Input input;
-    KtFile ktFile; // concrete syntax tree
+    Map<Integer, ASTNode> nodes; // Maybe replace with PsiTree?
 
     @Setter
-    @NonFinal
     FirFile firFile;
+
+    public KotlinSource(Parser.Input input,
+                        @Nullable PsiFile psiFile) {
+        this.input = input;
+        this.nodes = map(psiFile);
+    }
+
+    // Map the PsiFile ahead of time so that the Disposable may be disposed early and free up memory.
+    private Map<Integer, ASTNode> map(@Nullable PsiFile psiFile) {
+        Map<Integer, ASTNode> result = new HashMap<>();
+        if (psiFile == null) {
+            return result;
+        }
+
+        String source = input.getSource(new InMemoryExecutionContext()).readFully();
+        Set<PsiElement> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        PsiElementVisitor v = new PsiElementVisitor() {
+            @Override
+            public void visitElement(@NotNull PsiElement element) {
+                if (!(element instanceof KtFile) && element.getTextLength() != 0) {
+                    // Set the node at the cursor to the last visited element.
+                    result.put(element.getTextRange().getStartOffset(), element.getNode());
+                    assert source.substring(element.getTextRange().getStartOffset(), element.getTextRange().getEndOffset()).equals(element.getText());
+                }
+
+                for (PsiElement child : element.getChildren()) {
+                    if (visited.add(child)) {
+                        visitElement(child);
+                    }
+                }
+
+                if (element.getNextSibling() != null && visited.add(element.getNextSibling())) {
+                    visitElement(element.getNextSibling());
+                }
+            }
+        };
+        v.visitElement(psiFile);
+        return result;
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -76,7 +77,7 @@ class LambdaTest implements RewriteTest {
           kotlin(
             """
               fun method ( ) {
-                  val lambda: suspend ( ) -> Int = suspend { 1 }
+                  val lambda : suspend ( ) -> Int = suspend { 1 }
               }
               """
           )
@@ -90,7 +91,7 @@ class LambdaTest implements RewriteTest {
           kotlin(
             """
               fun method ( ) {
-                  val lambda: suspend ( Int ) -> Int = { number : Int -> number * number }
+                  val lambda : suspend ( Int ) -> Int = { number : Int -> number * number }
               }
               """
           )
@@ -116,9 +117,9 @@ class LambdaTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              fun method() {
-                  val list = listOf(1, 2, 3)
-                  list.filterIndexed { index, _ -> index % 2 == 0 }
+              fun method ( ) {
+                  val list = listOf ( 1 , 2 , 3 )
+                  list . filterIndexed { index , _ -> index % 2 == 0 }
               }
               """
           )
@@ -134,7 +135,7 @@ class LambdaTest implements RewriteTest {
               package foo
               class Bar {
                   companion object {
-                      fun bar(e: Any) {
+                      fun bar ( e : Any ) {
                       }
                   }
               }
@@ -144,7 +145,7 @@ class LambdaTest implements RewriteTest {
             """
               import foo.Bar
               fun test() {
-                  val a = Bar.bar {
+                  val a = Bar . bar {
                       _ : Any? ->
                   }
               }
@@ -162,7 +163,7 @@ class LambdaTest implements RewriteTest {
               package foo
               class Bar {
                   companion object {
-                      fun bar(e: Any) {
+                      fun bar ( e : Any ) {
                       }
                   }
               }
@@ -172,8 +173,8 @@ class LambdaTest implements RewriteTest {
             """
               import foo.Bar
               fun test() {
-                  val a = Bar.bar {
-                      _ : kotlin.Int? ->
+                  val a = Bar . bar {
+                      _ : kotlin . Int? ->
                   }
               }
               """

--- a/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
@@ -192,15 +192,17 @@ class WhenTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              fun method(i: Any) {
+              package foo.bar
+              import java.util.List
+              fun method ( i : Any ) {
                   val lhs = true
                   val rhs = true
-                  when (i) {
-                      1, (lhs && rhs || isTrue()) -> {
+                  when ( i ) {
+                      1, ( lhs && rhs || isTrue() ) -> {
                       }
                   }
               }
-              fun isTrue() = true
+              fun isTrue ( ) = true
               """
           )
         );
@@ -212,8 +214,8 @@ class WhenTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              fun method(a: Any) {
-                   val any = (if (a is Boolean) "true" else "false")
+              fun method ( a : Any ) {
+                   val any = ( if ( a is Boolean ) "true" else "false" )
               }
               """
           )
@@ -226,8 +228,8 @@ class WhenTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              fun method(a: Any?) {
-                  ((((if (((a)) == ((null))) return))))
+              fun method ( a : Any? ) {
+                  ( ( ( ( if ( ( ( a ) ) == ( ( null ) ) ) return ) ) ) )
                   val r = a
               }
               """

--- a/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
@@ -205,4 +205,33 @@ class WhenTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/138")
+    @Test
+    void inParens() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method(a: Any) {
+                   val any = (if (a is Boolean) "true" else "false")
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/138")
+    @Test
+    void multipleDeSugaredParens() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method(a: Any?) {
+                  ((((if (((a)) == ((null))) return))))
+                  val r = a
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Changes:

- KotlinParserVisitor contains a map of cursor positions to the Kt PSI AST nodes.
- Updated visitElement to detect Parenthesized elements and Unary operators.

fixes #138
fixes #143