### PR TITLE
[WIP] Leverage PSI Tree to support multiple annotations parsing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(kotlin("stdlib"))
 
     testImplementation("org.assertj:assertj-core:latest.release")
+    testImplementation("org.simpleframework:simple-xml:2.7.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")
     testImplementation("org.junit-pioneer:junit-pioneer:2.0.0")

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor;
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile;
 import org.jetbrains.kotlin.fir.declarations.FirFile;
 import org.jetbrains.kotlin.psi.KtElement;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Parser;
 
 import java.util.*;
@@ -33,6 +34,7 @@ import java.util.*;
 public class KotlinSource {
     Parser.Input input;
     Map<Integer, ASTNode> nodes; // Maybe replace with PsiTree?
+    PsiTree psiTree;
 
     @Setter
     FirFile firFile;
@@ -41,6 +43,7 @@ public class KotlinSource {
                         @Nullable PsiFile psiFile) {
         this.input = input;
         this.nodes = map(psiFile);
+        this.psiTree = new PsiTree(psiFile, input.getSource(new InMemoryExecutionContext()).readFully());
     }
 
     // Map the PsiFile ahead of time so that the Disposable may be disposed early and free up memory.

--- a/src/main/java/org/openrewrite/kotlin/internal/PsiTree.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/PsiTree.java
@@ -73,6 +73,10 @@ public class PsiTree {
         Node parent;
         PsiElement psiElement;
 
+        @Nullable
+        Node findFirstChildByType(String targetType) {
+            return childNodes.stream().filter(n -> n.getType().equals(targetType)).findFirst().orElse(null);
+        }
 
         @Override
         public boolean equals(Object obj) {

--- a/src/main/java/org/openrewrite/kotlin/internal/PsiTreePrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/PsiTreePrinter.java
@@ -18,9 +18,7 @@ package org.openrewrite.kotlin.internal;
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement;
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class PsiTreePrinter {
     private static final String TAB = "    ";
@@ -47,18 +45,18 @@ public class PsiTreePrinter {
     public static String printPsiTree(PsiTree psiTree) {
         StringBuilder sb = new StringBuilder();
 
-        // 0. Source code
-        sb.append("------------").append("\n");
-        sb.append("Source code with index").append("\n");
-        sb.append(printIndexedSourceCode(psiTree.getSource())).append("\n");
-
-        // 1. print Tokens
+        // 0. print Tokens
         sb.append("------------").append("\n");
         sb.append("PSI Tokens").append("\n");
         for (int i = 0; i < psiTree.getTokens().size(); i++) {
             PsiToken t = psiTree.getTokens().get(i);
             sb.append(i).append(": ").append(t).append("\n");
         }
+
+        // 1. Source code
+        sb.append("------------").append("\n");
+        sb.append("Source code with index").append("\n");
+        sb.append(printIndexedSourceCode(psiTree.getSource())).append("\n");
 
         // 2. print AST
         PsiTreePrinter treePrinter = new PsiTreePrinter();
@@ -74,7 +72,7 @@ public class PsiTreePrinter {
         line.append(leftPadding(depth));
         line.append(" ")
             .append(psiElement.getTextRange())
-            .append(" | Type:")
+            .append(" | ")
             .append(psiElement.getNode().getElementType())
             .append(" | Text: \"")
             .append(truncate(psiElement.getText()).replace("\n", "\\n"))
@@ -107,15 +105,26 @@ public class PsiTreePrinter {
         int count = 0;
         String[] lines = sourceCode.split("\n");
         StringBuilder result = new StringBuilder();
+        Queue<Integer> digits = new ArrayDeque<>();
 
         for (String line : lines) {
             StringBuilder spacesSb = new StringBuilder();
             for (int i = 0; i < line.length(); i++) {
                 if (count % 10 == 0) {
-                    spacesSb.append((count / 10) % 10);
+                    String numStr = Integer.toString(count);
+                    for (int j = 0; j < numStr.length(); j++) {
+                        char c = numStr.charAt(j);
+                        int digit = Character.getNumericValue(c);
+                        digits.add(digit);
+                    }
+                }
+
+                if (!digits.isEmpty()) {
+                    spacesSb.append(digits.poll()) ;
                 } else {
                     spacesSb.append(" ");
                 }
+
                 count++;
             }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -82,4 +82,42 @@ class AnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/156")
+    @Test
+    void annotationUseSiteTarget() {
+        rewriteRun(
+          kotlin(
+            """
+              annotation class Ann
+              class Test {
+                  @set : Ann
+                  @get : Ann
+                  var name: String = ""
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/156")
+    @Test
+    void multipleAnnotationUseSite() {
+        rewriteRun(
+          kotlin(
+            """
+              import org.simpleframework.xml.Attribute
+              import org.simpleframework.xml.Namespace
+              import org.simpleframework.xml.Root
+
+              class LibraryPom {
+                  @set:Attribute(name = "schemaLocation", required = false)
+                  @get:Attribute(name = "schemaLocation", required = false)
+                  @Namespace(reference = "http://www.w3.org/2001/XMLSchema-instance", prefix = "xsi")
+                  var mSchemaLocation: String = ""
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Leverage the PSI tree to support multiple annotations parsing.
Since FIR doesn't maintain the order of leading annotations, but we care about the orders, This PR attempts to leverage the PSI tree to support multiple annotations parsing.

fixes https://github.com/openrewrite/rewrite-kotlin/issues/156
