### PR TITLE
Automatically detect and convert Statements to StatementExpression where Expressions are required.

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -15,14 +15,14 @@
  */
 package org.openrewrite.kotlin.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
-@SuppressWarnings("RedundantVisibilityModifier")
+@SuppressWarnings({"RedundantSuppression", "RedundantNullableReturnType"})
 class AnnotationTest implements RewriteTest {
 
     @Test
@@ -150,7 +150,7 @@ class AnnotationTest implements RewriteTest {
         );
     }
 
-    @Disabled("FirValueParameter is supposed to have FirAnnotation somewhere but didn't find it")
+    @ExpectedToFail("FirValueParameter is supposed to have FirAnnotation somewhere but didn't find it")
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/173")
     @Test
     void constructorParameterWithAnnotation() {
@@ -163,6 +163,19 @@ class AnnotationTest implements RewriteTest {
                   val bar : String
                   ) {
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void conditionalParameter() {
+        rewriteRun(
+          kotlin(
+            """
+              annotation class A ( val s : String )
+              @A( if ( true ) "1" else "2" )
+              class Test
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/ArrayTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ArrayTest.java
@@ -68,4 +68,27 @@ class ArrayTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void conditionalArraySize() {
+        rewriteRun(
+          kotlin(
+            """
+              val arr = IntArray ( if (true) else 1 )
+              """
+          )
+        );
+    }
+
+    @Test
+    void conditionalArrayAccess() {
+        rewriteRun(
+          kotlin(
+            """
+              val arr = IntArray ( 1 )
+              val a = arr [ if (true) 0 else 1 ]
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/AssignmentOperationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AssignmentOperationTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"KotlinConstantConditions", "ConstantConditionIf"})
 class AssignmentOperationTest implements RewriteTest {
 
     @Test
@@ -72,6 +73,20 @@ class AssignmentOperationTest implements RewriteTest {
               fun method ( ) {
                 var n = 0
                 n /= 5
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void conditionalAssignment() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( ) {
+                var n = 84
+                n /= if (true) 42 else 21
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
@@ -283,8 +283,8 @@ class BinaryTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              data class Foo(val aliases: List<String>) {
-                  fun names() = listOf(canonicalName) + aliases
+              data class Foo ( val aliases : List < String > ) {
+                  fun names ( ) = listOf ( canonicalName ) + aliases
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
-@SuppressWarnings({"RemoveEmptyClassBody", "RedundantVisibilityModifier"})
+@SuppressWarnings({"RemoveEmptyClassBody", "RedundantVisibilityModifier", "SortModifiers", "ClassName"})
 class ClassDeclarationTest implements RewriteTest {
 
     @Test
@@ -30,7 +30,7 @@ class ClassDeclarationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              package some.package.name
+              package some.other.name
               class A { }
               class B { }
               """
@@ -198,7 +198,7 @@ class ClassDeclarationTest implements RewriteTest {
     @Test
     void explicitInlineConstructor() {
         rewriteRun(
-          kotlin("class Test internal constructor ()")
+          kotlin("class Test internal constructor ( )")
         );
     }
 
@@ -277,9 +277,9 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
               sealed class InvalidField {
-                abstract val field: String
+                abstract val field : String
               }
-              data class InvalidEmail( val errors : List<String> ) : InvalidField ( ) {
+              data class InvalidEmail ( val errors : List < String > ) : InvalidField ( ) {
                 override val field : String = "email"
               }
               """
@@ -296,7 +296,7 @@ class ClassDeclarationTest implements RewriteTest {
               sealed interface InvalidField {
                 val field : String
               }
-              data class InvalidEmail( val errors : List<String> ) : InvalidField {
+              data class InvalidEmail ( val errors : List < String > ) : InvalidField {
                 override val field : String = "email"
               }
               """
@@ -327,7 +327,7 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin("""
             class Test {
                 init {
-                    println( "Hello, world!" )
+                    println ( "Hello, world!" )
                 }
             }
             """)
@@ -373,9 +373,9 @@ class ClassDeclarationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              abstract class Test(arg: Test.() -> Unit = {}) {
+              abstract class Test ( arg : Test . ( ) -> Unit = { } ) {
                   init {
-                      arg()
+                      arg ( )
                   }
               }
               """
@@ -389,7 +389,7 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
               @Repeatable
-              annotation class A (val s : String )
+              annotation class A ( val s : String )
               """
           ),
           kotlin(

--- a/src/test/java/org/openrewrite/kotlin/tree/DoWhileTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/DoWhileTest.java
@@ -29,7 +29,7 @@ class DoWhileTest implements RewriteTest {
             """
               fun test() {
                   var i = 0
-                  do { i++ } while ( i < 10 )
+                  do { i ++ } while ( i < 10 )
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/FieldAccessTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/FieldAccessTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
+@SuppressWarnings("RedundantNullableReturnType")
 class FieldAccessTest implements RewriteTest {
 
     @Test
@@ -138,7 +139,7 @@ class FieldAccessTest implements RewriteTest {
           })),
           kotlin(
             """
-              val pattern = java.util.regex.Pattern.compile(".*")
+              val pattern = java . util . regex . Pattern . compile ( ".*" )
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/ForLoopTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ForLoopTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"ControlFlowWithEmptyBody", "RemoveForLoopIndices"})
 class ForLoopTest implements RewriteTest {
 
     @Test
@@ -62,7 +63,7 @@ class ForLoopTest implements RewriteTest {
           kotlin(
             """
               fun method ( ) {
-                  for ( i in 1..42 ) {
+                  for ( i in 1 .. 42 ) {
                       println ( i )
                   }
               }

--- a/src/test/java/org/openrewrite/kotlin/tree/IfTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/IfTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"RedundantExplicitType", "KotlinConstantConditions", "ControlFlowWithEmptyBody", "CascadeIf", "LiftReturnOrAssignment"})
 class IfTest implements RewriteTest {
 
     @Test
@@ -97,11 +98,41 @@ class IfTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              fun method(n: Int): List<Int> {
-                  if (n == 0) return emptyList()
-                  if (n == 1) return listOf(1)
-                  val list = mutableListOf<Int>()
+              fun method ( n : Int ) : List < Int > {
+                  if ( n == 0 ) return emptyList ( )
+                  if ( n == 1 ) return listOf ( 1 )
+                  val list = mutableListOf < Int > ( )
                   return list
+              }
+              """
+          )
+        );
+    }
+
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/138")
+    @Test
+    void inParens() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( a : Any ) {
+                   val any = ( if ( a is Boolean ) "true" else "false" )
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/138")
+    @Test
+    void multipleDeSugaredParens() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( a : Any? ) {
+                  ( ( ( ( if ( ( ( a ) ) == ( ( null ) ) ) return ) ) ) )
+                  val r = a
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/ImportTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ImportTest.java
@@ -50,7 +50,7 @@ class ImportTest implements RewriteTest {
             """
               package a.b
               class Target {
-                  inline fun method() {}
+                  inline fun method ( ) { }
               }
               """
           ),

--- a/src/test/java/org/openrewrite/kotlin/tree/LabelTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/LabelTest.java
@@ -78,7 +78,7 @@ class LabelTest implements RewriteTest {
               fun test ( ) {
                   var i = 0
                   labeled@ do {
-                      i++
+                      i ++
                       break@labeled
                   } while ( i < 10 )
               }
@@ -93,7 +93,7 @@ class LabelTest implements RewriteTest {
           kotlin(
             """
               fun test ( ) {
-                  labeled@ for (i in 1..10) {
+                  labeled@ for ( i in 1 .. 10 ) {
                       break@labeled
                   }
               }

--- a/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
@@ -16,12 +16,12 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings("RemoveRedundantQualifierName")
 class LambdaTest implements RewriteTest {
 
     @Test
@@ -62,7 +62,7 @@ class LambdaTest implements RewriteTest {
                   abstract fun fields ( ) : List < Pair < String , Any ? > >
                   
                   fun inputValues ( ) : List < Pair < String , Any ? > > {
-                      return fields ( ) .filter { ( k , _ ) -> ! defaults . contains ( k ) }
+                      return fields ( ) . filter { ( k , _ ) -> ! defaults . contains ( k ) }
                   }
               }
               """
@@ -104,8 +104,8 @@ class LambdaTest implements RewriteTest {
           kotlin(
             """
               fun method() {
-                  val list = listOf(1, 2, 3)
-                  list.filterIndexed { index, ignored -> index % 2 == 0 }
+                  val list = listOf ( 1 , 2 , 3 )
+                  list . filterIndexed { index , ignored -> index % 2 == 0 }
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"UnusedReceiverParameter", "RedundantSuspendModifier"})
 class MethodDeclarationTest implements RewriteTest {
 
     @Test
@@ -140,7 +141,7 @@ class MethodDeclarationTest implements RewriteTest {
     @Test
     void genericTypeParameters() {
         rewriteRun(
-          kotlin("fun <T : Number > method ( type : T ) { }")
+          kotlin("fun < T : Number > method ( type : T ) { }")
         );
     }
 
@@ -205,7 +206,7 @@ class MethodDeclarationTest implements RewriteTest {
               suspend fun example (
                 title : String ,
                 verifyUnique : suspend ( String ) -> Boolean
-              ) : String = TODO()
+              ) : String = TODO ( )
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"RedundantVisibilityModifier", "PropertyName", "RedundantNullableReturnType", "UnusedReceiverParameter"})
 class MethodInvocationTest implements RewriteTest {
 
     @Test
@@ -489,6 +490,18 @@ class MethodInvocationTest implements RewriteTest {
                 foo . bar . format ( "" , * x )
               }
               """)
+        );
+    }
+
+    @Test
+    void conditionalArgument() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( s : String ) { }
+              val x = method ( if ( true ) "foo" else "bar" )
+              """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodReferenceTest.java
@@ -65,4 +65,19 @@ class MethodReferenceTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void conditionalFieldReference() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test ( val a : Int , val b : Int )
+              fun method ( ) {
+                  val l = listOf ( Test ( 42 , 24 ) )
+                  l . map { if ( true ) Test :: a else Test :: b }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/NewClassTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/NewClassTest.java
@@ -25,7 +25,7 @@ class NewClassTest implements RewriteTest {
     @Test
     void multipleParameters() {
         rewriteRun(
-          kotlin("class Test(val a: Int, val b: Int)"),
+          kotlin("class Test ( val a : Int , val b : Int )"),
           kotlin("val t = Test ( 1 , 2 )")
         );
     }
@@ -87,6 +87,14 @@ class NewClassTest implements RewriteTest {
               val type : a . b . Test . Inner = a . b . Test . Inner ( )
               """
           )
+        );
+    }
+
+    @Test
+    void conditionalConstructorArg() {
+        rewriteRun(
+          kotlin("class Test ( val a : Int )"),
+          kotlin("val t = Test ( if ( true ) 4 else 2 )")
         );
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/ReturnTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ReturnTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"RedundantUnitReturnType", "CatchMayIgnoreException", "ConstantConditionIf"})
 class ReturnTest implements RewriteTest {
 
     @Test
@@ -68,7 +69,7 @@ class ReturnTest implements RewriteTest {
             """
               fun method ( i : Int ) : String {
                   return when {
-                      i . mod ( 2 ) . equals ( 0 ) -> "even"
+                      i . mod ( 2 ) == 0 -> "even"
                       else -> "odd"
                   }
               }
@@ -86,6 +87,19 @@ class ReturnTest implements RewriteTest {
                   return try {
                   } catch ( e : Exception ) {
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void conditionalReturnedValue() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( ) : String {
+                  return if ( true ) "42" else "24"
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/TryCatchTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/TryCatchTest.java
@@ -58,8 +58,8 @@ class TryCatchTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              val throwable: Throwable? = try {
-              } catch (caught: Throwable) {
+              val throwable : Throwable? = try {
+              } catch ( caught : Throwable ) {
                  caught
               } as? Throwable
               """

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -16,11 +16,13 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"UnusedReceiverParameter", "PropertyName", "RemoveCurlyBracesFromTemplate", "UnnecessaryStringEscape", "RedundantGetter"})
 class VariableDeclarationTest implements RewriteTest {
 
     @Test
@@ -103,7 +105,7 @@ class VariableDeclarationTest implements RewriteTest {
               val a = "Hello"
               val b = "World"
               val c = "${a} ${b}!"
-                          
+              
               val after = 0
               """
           )
@@ -118,13 +120,15 @@ class VariableDeclarationTest implements RewriteTest {
               val a = "Hello"
               val b = "World"
               val c = "$a $b!"
-                          
+              
               val after = 0
               """
           )
         );
     }
 
+    @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/172")
     @Test
     void propertyAccessor() {
         rewriteRun(
@@ -134,14 +138,16 @@ class VariableDeclarationTest implements RewriteTest {
                   val value = 10
               }
               val a = Test ( )
-              val b = "${a.value}"
-                          
+              val b = " ${ a . value }"
+              
               val after = 0
               """
           )
         );
     }
 
+    @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/172")
     @Test
     void multipleFieldAccess() {
         rewriteRun(
@@ -153,9 +159,9 @@ class VariableDeclarationTest implements RewriteTest {
                       val innerValue = 10
                   }
               }
-                          
+              
               val a = Test ( )
-              val b = "${a.testValue.innerValue}"
+              val b = "${ a . testValue . innerValue }"
               """
           )
         );
@@ -192,7 +198,7 @@ class VariableDeclarationTest implements RewriteTest {
           kotlin(
             """
               package org.foo
-              class Test<T>
+              class Test < T >
               """
           ),
           kotlin(
@@ -251,7 +257,7 @@ class VariableDeclarationTest implements RewriteTest {
             """
               val first : String = "1"
               val second : Int = 2
-                         
+              
               val l = listOf ( "foo" to first , "bar" to second )
               """
           )
@@ -264,7 +270,7 @@ class VariableDeclarationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              val t = SomeInput.Test
+              val t = SomeInput . Test
               """
           )
         );
@@ -277,14 +283,14 @@ class VariableDeclarationTest implements RewriteTest {
           kotlin(
             """
               class StringValue {
-                  val value: String = ""
+                  val value : String = ""
               }
               """
           ),
           kotlin(
             """
-              fun method(input : Any) {
-                  val split = (input as StringValue).value.split("-").toTypedArray()
+              fun method ( input : Any ) {
+                  val split = ( input as StringValue ) . value . split ( "-" ) . toTypedArray ( )
               }
               """
           )
@@ -320,13 +326,14 @@ class VariableDeclarationTest implements RewriteTest {
         );
     }
 
+    @SuppressWarnings("RedundantSetter")
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/93")
     @Test
     void setter() {
         rewriteRun(
           kotlin(
             """
-              var s: String = ""
+              var s : String = ""
                   set ( value ) {
                       field = value
                   }

--- a/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
+@SuppressWarnings({"LiftReturnOrAssignment", "IntroduceWhenSubject"})
 class WhenTest implements RewriteTest {
 
     @Test
@@ -30,14 +31,12 @@ class WhenTest implements RewriteTest {
             """
               class A {
                 val a = 1
-                fun method() {
-                    val a = A()
+                fun method ( ) {
+                    val a = A ( )
                     val b = a
                 }
               }
-              """, spec -> spec.afterRecipe(cu -> {
-                System.out.println();
-            })
+              """
           )
         );
     }
@@ -103,7 +102,7 @@ class WhenTest implements RewriteTest {
             """
               fun method ( i : Int ) : String {
                   when {
-                      i . mod ( 2 ) . equals ( 0 ) -> return "even"
+                      i . mod ( 2 ) == 0 -> return "even"
                       else -> return "odd"
                   }
               }
@@ -203,35 +202,6 @@ class WhenTest implements RewriteTest {
                   }
               }
               fun isTrue ( ) = true
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/138")
-    @Test
-    void inParens() {
-        rewriteRun(
-          kotlin(
-            """
-              fun method ( a : Any ) {
-                   val any = ( if ( a is Boolean ) "true" else "false" )
-              }
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/138")
-    @Test
-    void multipleDeSugaredParens() {
-        rewriteRun(
-          kotlin(
-            """
-              fun method ( a : Any? ) {
-                  ( ( ( ( if ( ( ( a ) ) == ( ( null ) ) ) return ) ) ) )
-                  val r = a
-              }
               """
           )
         );


### PR DESCRIPTION
Changes:
- Added optional conversion to StatementExpressions in convert and convertAll.
- Enabled Statement conversion on all existing calls of `convert` and `convertAll` that expect expressions.
- Replaced all `visitElement`(s) that cast to an Expression with `convert`.