### PR TITLE
Fix paring error of annotations on constructor parameters - 2

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -2737,14 +2737,8 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         List<FirAnnotation> firAnnotations = valueParameter.getAnnotations();
         if (generatedFirProperties.containsKey(range)) {
             FirProperty generatedFirProperty = generatedFirProperties.get(range);
-            if (generatedFirProperty.getGetter() != null &&
-                !generatedFirProperty.getGetter().getAnnotations().isEmpty()) {
-                firAnnotations.addAll(generatedFirProperty.getGetter().getAnnotations());
-            }
-            if (generatedFirProperty.getSetter() != null &&
-                !generatedFirProperty.getSetter().getAnnotations().isEmpty()) {
-                firAnnotations.addAll(generatedFirProperty.getSetter().getAnnotations());
-            }
+            firAnnotations.addAll(generatedFirProperty.getGetter() != null ? generatedFirProperty.getGetter().getAnnotations() : emptyList());
+            firAnnotations.addAll(generatedFirProperty.getSetter() != null ? generatedFirProperty.getSetter().getAnnotations() : emptyList());
         }
 
         List<J.Annotation> annotations = mapModifiers(firAnnotations, valueParameter.getName().asString());

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite.kotlin.internal;
 
 import org.jetbrains.kotlin.*;
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode;
+import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange;
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement;
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement;
 import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil;
@@ -90,6 +91,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     private int cursor;
 
     private final Map<Integer, ASTNode> nodes;
+    private final Map<TextRange, FirProperty> generatedFirProperties;
 
     // Associate top-level function and property declarations to the file.
     @Nullable
@@ -107,11 +109,13 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         this.ctx = ctx;
         this.firSession = firSession;
         this.nodes = kotlinSource.getNodes();
+        this.generatedFirProperties = new HashMap<>();
     }
 
     @Override
     public J visitFile(FirFile file, ExecutionContext ctx) {
         currentFile = file;
+        generatedFirProperties.clear();
 
         List<J.Annotation> annotations = null;
 
@@ -2727,11 +2731,23 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     @Override
     public J visitValueParameter(FirValueParameter valueParameter, ExecutionContext ctx) {
         Space prefix = whitespace();
-
-        List<J> modifiers = emptyList();
         Markers markers = Markers.EMPTY;
 
-        List<J.Annotation> annotations = mapModifiers(valueParameter.getAnnotations(), valueParameter.getName().asString());
+        TextRange range = new TextRange(valueParameter.getSource().getStartOffset(), valueParameter.getSource().getEndOffset());
+        List<FirAnnotation> firAnnotations = valueParameter.getAnnotations();
+        if (generatedFirProperties.containsKey(range)) {
+            FirProperty generatedFirProperty = generatedFirProperties.get(range);
+            if (generatedFirProperty.getGetter() != null &&
+                !generatedFirProperty.getGetter().getAnnotations().isEmpty()) {
+                firAnnotations.addAll(generatedFirProperty.getGetter().getAnnotations());
+            }
+            if (generatedFirProperty.getSetter() != null &&
+                !generatedFirProperty.getSetter().getAnnotations().isEmpty()) {
+                firAnnotations.addAll(generatedFirProperty.getSetter().getAnnotations());
+            }
+        }
+
+        List<J.Annotation> annotations = mapModifiers(firAnnotations, valueParameter.getName().asString());
 
         List<JRightPadded<J.VariableDeclarations.NamedVariable>> vars = new ArrayList<>(1); // adjust size if necessary
         Space namePrefix = EMPTY;
@@ -3451,6 +3467,9 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 jcEnums.add(declaration);
             } else if (declaration instanceof FirPrimaryConstructor) {
                 firPrimaryConstructor = (FirPrimaryConstructor) declaration;
+            } else if (declaration instanceof FirProperty && declaration.getSource().getKind() instanceof KtFakeSourceElementKind.PropertyFromParameter) {
+                TextRange range = new TextRange(declaration.getSource().getStartOffset(), declaration.getSource().getEndOffset());
+                generatedFirProperties.put(range, (FirProperty) declaration);
             } else {
                 // We aren't interested in the generated values.
                 if (ClassKind.ENUM_CLASS == classKind && declaration.getSource() != null &&

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -3467,7 +3467,9 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 jcEnums.add(declaration);
             } else if (declaration instanceof FirPrimaryConstructor) {
                 firPrimaryConstructor = (FirPrimaryConstructor) declaration;
-            } else if (declaration instanceof FirProperty && declaration.getSource().getKind() instanceof KtFakeSourceElementKind.PropertyFromParameter) {
+            } else if (declaration instanceof FirProperty &&
+                       declaration.getSource() != null &&
+                       declaration.getSource().getKind() instanceof KtFakeSourceElementKind.PropertyFromParameter) {
                 TextRange range = new TextRange(declaration.getSource().getStartOffset(), declaration.getSource().getEndOffset());
                 generatedFirProperties.put(range, (FirProperty) declaration);
             } else {

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -150,7 +149,6 @@ class AnnotationTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("FirValueParameter is supposed to have FirAnnotation somewhere but didn't find it")
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/173")
     @Test
     void constructorParameterWithAnnotation() {
@@ -163,6 +161,19 @@ class AnnotationTest implements RewriteTest {
                   val bar : String
                   ) {
               }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/173")
+    @Test
+    void getUseSiteOnConstructorParams() {
+        rewriteRun(
+          kotlin("@Repeatable annotation class A"),
+          kotlin(
+            """
+              class Example( @get : A @set : A var foo: String, @get : A val bar: String)
               """
           )
         );


### PR DESCRIPTION
Fixes #173 .

https://github.com/openrewrite/rewrite-kotlin/pull/175 is the 1st approach to fix this problem. 
Discussed with @traceyyoshima that one might break something since we should not parse `fake` kind FIR element (generated by the compiler but not in the source code).
This is a 2nd approach to fix #173 