### PR TITLE
Fix parsing error of annotation on explicit getter/setter

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1809,26 +1809,72 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 }
 
                 int saveCursor = cursor;
-                whitespace();
+                Space s0 = whitespace();
 
+                PsiElement currentPsiElement = getCurrentPsiNode();
+                KtModifierList modifierList = null;
+                List<J.Annotation> annos = new ArrayList<>();
+
+                if (currentPsiElement instanceof KtAnnotationEntry) {
+                    modifierList = PsiTreeUtil.getParentOfType(currentPsiElement, KtModifierList.class);
+                }
+
+                if (modifierList != null) {
+                    List<FirAnnotation> firAnnotations = new ArrayList<>();
+                    firAnnotations.addAll(property.getAnnotations());
+                    firAnnotations.addAll(property.getGetter().getAnnotations());
+                    firAnnotations.addAll(property.getSetter().getAnnotations());
+                    mapModifierList(modifierList, firAnnotations, annos);
+                    if (!annos.isEmpty()) {
+                        J.Annotation a0 = annos.get(0).withPrefix(s0);
+                        annos.set(0, a0);
+                    }
+                }
+
+                boolean hasAnno = !annos.isEmpty();
+                if (hasAnno) {
+                    saveCursor = cursor;
+                } else {
+                    cursor(saveCursor);
+                }
+
+                Space s1 = whitespace();
                 String methodName = source.substring(cursor, cursor + 3);
                 switch (methodName) {
                     case "get":
-                        cursor(saveCursor);
+                        if (!hasAnno) {
+                            cursor(saveCursor);
+                        }
                         if (isValidGetter(property.getGetter())) {
                             getter = (J.MethodDeclaration) visitElement(property.getGetter(), ctx);
                             if (receiver != null) {
                                 getter = getter.withParameters(ListUtils.concat(receiver, getter.getParameters()));
                             }
+
+                            if (!annos.isEmpty()) {
+                                getter = getter.withName(getter.getName().withPrefix(s1));
+                                getter = getter.withLeadingAnnotations(annos);
+                            } else {
+                                getter = getter.withPrefix(s1);
+                            }
                             expressions.add(getter);
                         }
                         break;
                     case "set":
-                        cursor(saveCursor);
+                        if (!hasAnno) {
+                            cursor(saveCursor);
+                        }
                         if (isValidSetter(property.getSetter())) {
                             setter = (J.MethodDeclaration) visitElement(property.getSetter(), ctx);
                             if (receiver != null) {
                                 setter = setter.withParameters(ListUtils.concat(receiver, setter.getParameters()));
+                            }
+
+                            if (!annos.isEmpty()) {
+                                setter = setter.withName(setter.getName().withPrefix(s1));
+                                setter = setter.withLeadingAnnotations(annos);
+                            } else {
+                                setter = setter.withPrefix(s1);
                             }
                             expressions.add(setter);
                         }
@@ -1837,27 +1883,70 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                         cursor(saveCursor);
                         break;
                 }
-                saveCursor = cursor;
-                whitespace();
 
+                saveCursor = cursor;
+                s0 = whitespace();
+                List<J.Annotation> annos2 = new ArrayList<>();
+
+                currentPsiElement = getCurrentPsiNode();
+                modifierList = null;
+
+                if (currentPsiElement instanceof KtAnnotationEntry) {
+                    modifierList = PsiTreeUtil.getParentOfType(currentPsiElement, KtModifierList.class);
+                }
+
+                if (modifierList != null) {
+                    List<FirAnnotation> firAnnotations = new ArrayList<>();
+                    firAnnotations.addAll(property.getAnnotations());
+                    firAnnotations.addAll(property.getGetter().getAnnotations());
+                    firAnnotations.addAll(property.getSetter().getAnnotations());
+                    mapModifierList(modifierList, firAnnotations, annos2);
+                    if (!annos2.isEmpty()) {
+                        J.Annotation a0 = annos2.get(0).withPrefix(s0);
+                        annos2.set(0, a0);
+                    }
+                }
+
+                hasAnno = !annos2.isEmpty();
+                if (hasAnno) {
+                    saveCursor = cursor;
+                } else {
+                    cursor(saveCursor);
+                }
+
+                Space s2 = whitespace();
                 methodName = source.substring(cursor, cursor + 3);
                 switch (methodName) {
                     case "get":
-                        cursor(saveCursor);
+                        if (!hasAnno) {
+                            cursor(saveCursor);
+                        }
                         if (isValidGetter(property.getGetter())) {
                             getter = (J.MethodDeclaration) visitElement(property.getGetter(), ctx);
                             if (receiver != null) {
                                 getter = getter.withParameters(ListUtils.concat(receiver, getter.getParameters()));
                             }
+
+                            if (!annos.isEmpty()) {
+                                getter = getter.withName(getter.getName().withPrefix(s2));
+                                getter = getter.withLeadingAnnotations(annos2);
+                            }
                             expressions.add(getter);
                         }
                         break;
                     case "set":
-                        cursor(saveCursor);
+                        if (!hasAnno) {
+                            cursor(saveCursor);
+                        }
                         if (isValidSetter(property.getSetter())) {
                             setter = (J.MethodDeclaration) visitElement(property.getSetter(), ctx);
                             if (receiver != null) {
                                 setter = setter.withParameters(ListUtils.concat(receiver, setter.getParameters()));
+                            }
+
+                            if (!annos.isEmpty()) {
+                                setter = setter.withName(setter.getName().withPrefix(s2));
+                                setter = setter.withLeadingAnnotations(annos2);
                             }
                             expressions.add(setter);
                         }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1857,6 +1857,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                     }
 
                     J.MethodDeclaration m = (J.MethodDeclaration) visitElement(firPropertyAccessor, ctx);
+                    m = m.withPrefix(accessorPrefix);
                     if (receiver != null) {
                         m = m.withParameters(ListUtils.concat(receiver, m.getParameters()));
                     }
@@ -1866,8 +1867,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                             .withPrefix(EMPTY);
                     }
                     expressions.add(m);
-
-                    cursor(ktPropertyAccessor.getTextRange().getEndOffset());
                 }
             } else if (isValidGetter(property.getGetter()) && !isValidSetter(property.getSetter())) {
                 if (expressions == null) {

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1821,7 +1821,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                     expressions = new ArrayList<>(2);
                 }
                 List<KtPropertyAccessor> accessors = propertyNodeChildren.stream()
-                    .filter(c -> c instanceof KtPropertyAccessor)
+                    .filter(KtPropertyAccessor.class::isInstance)
                     .map(KtPropertyAccessor.class::cast)
                     .collect(toList());
                 if (accessors.size() > 2) {
@@ -1830,7 +1830,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
                 for (KtPropertyAccessor ktPropertyAccessor : accessors) {
                     Optional<KtDeclarationModifierList> maybeModifier = Arrays.stream(ktPropertyAccessor.getChildren())
-                        .filter(c -> c instanceof KtDeclarationModifierList)
+                        .filter(KtDeclarationModifierList.class::isInstance)
                         .map(KtDeclarationModifierList.class::cast)
                         .findFirst();
                     boolean hasAnnotationBeforeAccessors = maybeModifier.isPresent();

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1843,14 +1843,10 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                         mapModifierList(maybeModifier.get(), firAnnotations, annos);
                     }
 
+                    Space accessorPrefix = whitespace();
                     LeafPsiElement accessorNode = getGetterOrSetterNode(ktPropertyAccessor);
                     if (accessorNode == null) {
                         throw new RuntimeException("a ktPropertyAccessor node should have get or set");
-                    }
-
-                    Space accessorPrefix = EMPTY;
-                    if (accessorNode.getPrevSibling() instanceof PsiWhiteSpace) {
-                        accessorPrefix = Space.format(accessorNode.getPrevSibling().getText());
                     }
 
                     FirPropertyAccessor firPropertyAccessor = null;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1848,11 +1848,9 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                         throw new RuntimeException("a ktPropertyAccessor node should have get or set");
                     }
 
-                    PsiElement maybeWhiteSpace = accessorNode.getPrevSibling();
                     Space accessorPrefix = EMPTY;
-                    if (maybeWhiteSpace instanceof PsiWhiteSpace) {
-                        PsiWhiteSpace whiteSpace = (PsiWhiteSpace) maybeWhiteSpace;
-                        accessorPrefix = Space.format(whiteSpace.getText());
+                    if (accessorNode.getPrevSibling() instanceof PsiWhiteSpace) {
+                        accessorPrefix = Space.format(accessorNode.getPrevSibling().getText());
                     }
 
                     FirPropertyAccessor firPropertyAccessor = null;

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -169,6 +169,28 @@ class AnnotationTest implements RewriteTest {
     }
 
     @Test
+    void annotationOnExplicitGetter() {
+        rewriteRun(
+          kotlin(
+            """
+              annotation class A
+              class Test {
+                  public var stringRepresentation : String = ""
+
+                      @A
+                      get ( ) = field
+
+                      @A
+                      set ( value ) {
+                          field = value
+                      }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void conditionalParameter() {
         rewriteRun(
           kotlin(

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -187,8 +187,8 @@ class AnnotationTest implements RewriteTest {
               annotation class A
               class Test {
                   public var stringRepresentation : String = ""
-
                       @A
+                      // comment
                       get ( ) = field
 
                       @A


### PR DESCRIPTION
Fix parsing error of annotation on explicit getter/setter

also made an enhancement to
fixes https://github.com/openrewrite/rewrite-kotlin/issues/176

A failing test:

```java
    @Test
    void annotationOnExplicitGetter() {
        rewriteRun(
          kotlin(
            """
              annotation class A
              class Test {
                  public var stringRepresentation : String = ""
                      @A
                      get ( ) = field
                      @A
                      set ( value ) {
                          field = value
                      }
              }
              """
          )
        );
    }
```