### PR TITLE
Fix leading comments parsing error

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -91,6 +91,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     private int cursor;
 
     private final Map<Integer, ASTNode> nodes;
+    private final Map<Integer, ASTNode> allNodes;
     private final Map<TextRange, FirProperty> generatedFirProperties;
 
     // Associate top-level function and property declarations to the file.
@@ -109,6 +110,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         this.ctx = ctx;
         this.firSession = firSession;
         this.nodes = kotlinSource.getNodes();
+        this.allNodes = kotlinSource.getAllNodes();
         this.generatedFirProperties = new HashMap<>();
     }
 
@@ -1657,6 +1659,12 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
         List<J.Modifier> modifiers = emptyList();
         PsiElement currentNode = getCurrentPsiNode();
+
+        if (currentNode == null) {
+            currentNode = getCurrentPsiNodeByType(KtProperty.class);
+        }
+
+
         PsiElement propertyNode = currentNode instanceof KtProperty ? currentNode :
                 PsiTreeUtil.getParentOfType(currentNode, KtProperty.class);
         List<PsiElement> propertyNodeChildren = propertyNode != null ? Arrays.asList(propertyNode.getChildren()) : emptyList();
@@ -4626,6 +4634,15 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     private PsiElement getCurrentPsiNode() {
         if (nodes.containsKey(cursor)) {
             return nodes.get(cursor).getPsi();
+        }
+        return null;
+    }
+
+    @Nullable
+    private PsiElement getCurrentPsiNodeByType(Class type) {
+        if (allNodes.containsKey(cursor)) {
+            PsiElement psiElement = allNodes.get(cursor).getPsi();
+            return PsiTreeUtil.getParentOfType(psiElement, type);
         }
         return null;
     }

--- a/src/main/java/org/openrewrite/kotlin/internal/PsiTreePrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/PsiTreePrinter.java
@@ -159,7 +159,6 @@ public class PsiTreePrinter {
         connectToLatestSibling(depth);
         outputLines.add(line);
 
-        PsiUtilsKt.getAllChildren(psiElement);
         Iterator<PsiElement> iterator = PsiUtilsKt.getAllChildren(psiElement).iterator();
         while (iterator.hasNext()) {
             PsiElement it = iterator.next();

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -24,6 +24,21 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings({"UnusedReceiverParameter", "PropertyName", "RemoveCurlyBracesFromTemplate", "UnnecessaryStringEscape", "RedundantGetter"})
 class VariableDeclarationTest implements RewriteTest {
+    @Test
+    void leadingWhitespace() {
+        rewriteRun(
+          kotlin(
+            """
+            annotation class Ann
+            
+            // comment 1
+            
+            // comment 2
+            val a = 10
+            """
+          )
+        );
+    }
 
     @Test
     void singleVariableDeclaration() {


### PR DESCRIPTION
This PR attempts to fix the parsing error of leading comments for a property.
This change might need to be added to all `visitX()` methods from `FirDefaultVisitor` to cover leading comments for other types of FIR elements.
fixes https://github.com/openrewrite/rewrite-kotlin/issues/179
