### PR TITLE
Fix parsing error of CRLF before a variable declaration

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -778,8 +778,9 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
     @Override
     public <T> J visitConstExpression(FirConstExpression<T> constExpression, ExecutionContext ctx) {
-        String valueSource = source.substring(constExpression.getSource().getStartOffset(), constExpression.getSource().getEndOffset());
-        Space prefix = sourceBefore(valueSource);
+        Space prefix = whitespace();
+        String valueSource = source.substring(cursor, cursor + constExpression.getSource().getLighterASTNode().getTextLength());
+        skip(valueSource);
 
         Object value = constExpression.getValue();
         JavaType.Primitive type;

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -28,7 +28,16 @@ class VariableDeclarationTest implements RewriteTest {
     @Test
     void singleVariableDeclaration() {
         rewriteRun(
-          kotlin("val a = 1")
+          kotlin(
+            "val a = 1")
+        );
+    }
+
+    @Test
+    void singleVariableDeclarationWithCRLF() {
+        rewriteRun(
+          kotlin(
+            "\r\nval a = 1")
         );
     }
 


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-kotlin/issues/182
The root cause is [here](https://github.com/openrewrite/rewrite-kotlin/issues/182#issuecomment-1638870663)
The solution is never to use ASTNode offset on source code since it might be shifted. 