### PR TITLE
Updated Kotlin compiler configuration to set real PSI elements as the FirElement.source.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -119,12 +119,8 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
         List<J.Annotation> annotations = null;
 
-        PsiElement currentPsiNode = getCurrentPsiNode();
-        if (currentPsiNode instanceof KtAnnotationEntry) {
-            currentPsiNode = PsiTreeUtil.getParentOfType(currentPsiNode, KtFileAnnotationList.class);
-            annotations = mapFileAnnotations((KtFileAnnotationList) currentPsiNode, file.getAnnotations());
-        } else if (currentPsiNode instanceof KtFile) {
-            KtFileAnnotationList annotationList = PsiTreeUtil.findChildOfType(getCurrentPsiNode(), KtFileAnnotationList.class);
+        KtFileAnnotationList annotationList = PsiTreeUtil.findChildOfType(getPsiElement(file), KtFileAnnotationList.class);
+        if (annotationList != null) {
             annotations = mapFileAnnotations(annotationList, file.getAnnotations());
         }
 
@@ -214,6 +210,10 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             Space prefix = whitespace();
             skip(fullName);
             return TypeTree.build(fullName).withPrefix(prefix);
+        } else if (errorNamedReference.getSource() instanceof KtFakeSourceElement) {
+            KtNameReferenceExpression psi = (KtNameReferenceExpression) ((KtFakeSourceElement) errorNamedReference.getSource()).getPsi();
+            skip(psi.getReferencedName());
+            return TypeTree.build(psi.getReferencedName());
         } else {
             throw new UnsupportedOperationException("Unsupported error name reference type.");
         }
@@ -289,8 +289,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         } else {
             skip("{");
         }
-
-        JavaType closureType = null;
 
         boolean omitDestruct = false;
         List<JRightPadded<J>> paramExprs = new ArrayList<>(anonymousFunction.getValueParameters().size());
@@ -398,7 +396,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 params,
                 EMPTY,
                 body,
-                closureType);
+                null);
 
         return label != null ? label.withStatement(lambda) : lambda;
     }
@@ -1659,32 +1657,16 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         Markers markers = Markers.EMPTY;
 
         List<J.Modifier> modifiers = emptyList();
-        PsiElement currentNode = getCurrentPsiNode();
-        PsiElement propertyNode = currentNode instanceof KtProperty ? currentNode :
-                PsiTreeUtil.getParentOfType(currentNode, KtProperty.class);
-        List<PsiElement> propertyNodeChildren = propertyNode != null ? Arrays.asList(propertyNode.getChildren()) : emptyList();
+        PsiElement propertyNode = getPsiElement(property);
+        List<PsiElement> propertyNodeChildren = Arrays.asList(propertyNode.getChildren());
 
-        if (currentNode instanceof KtAnnotationEntry) {
-            currentNode = PsiTreeUtil.getParentOfType(currentNode, KtModifierList.class);
-        }
-
-        PsiElement parentNode = currentNode;
-        if (currentNode != null &&
-                !(currentNode instanceof KtProperty) &&
-                !(currentNode instanceof KtDestructuringDeclaration) &&
-                !(currentNode instanceof KtParameter)) {
-            parentNode = currentNode.getParent();
-            if (parentNode == null || parentNode.getTextRange().getStartOffset() != currentNode.getTextRange().getStartOffset()) {
-                parentNode = currentNode;
-            }
-        }
-
+        KtModifierList modifierList = PsiTreeUtil.findChildOfType(propertyNode, KtModifierList.class);
         List<J.Annotation> annotations = new ArrayList<>();
-        if (currentNode instanceof KtModifierList) {
-            modifiers = mapModifierList((KtModifierList) currentNode, collectFirAnnotations(property), annotations);
+        if (modifierList != null && modifierList.getTextRange().getStartOffset() == cursor) {
+            modifiers = mapModifierList(modifierList, collectFirAnnotations(property), annotations);
         }
 
-        String maybeValOrVarModifier = getValOrVarModifier(parentNode);
+        String maybeValOrVarModifier = getValOrVarModifier(propertyNode);
         if (maybeValOrVarModifier != null) {
             annotations.add(mapKModifierToAnnotation(maybeValOrVarModifier));
         }
@@ -1840,7 +1822,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                         .map(KtPropertyAccessor.class::cast)
                         .collect(toList());
                 if (accessors.size() > 2) {
-                    throw new RuntimeException("Detected oversized explicit property accessors from a property, should have setter/getter only");
+                    throw new RuntimeException("Detected over sized explicit property accessors from a property, should have setter/getter only");
                 }
 
                 for (KtPropertyAccessor ktPropertyAccessor : accessors) {
@@ -2033,7 +2015,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         Space prefix = whitespace();
         if (propertyAccessor.isGetter() || propertyAccessor.isSetter()) {
             Markers markers = Markers.EMPTY;
-            List<J> modifiers = emptyList();
+
             List<J.Annotation> annotations = emptyList();
 
             J.TypeParameters typeParameters = null;
@@ -2247,7 +2229,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     public J visitSimpleFunction(FirSimpleFunction simpleFunction, ExecutionContext ctx) {
         Space prefix = whitespace();
         Markers markers = Markers.EMPTY;
-        List<J> modifiers = emptyList();
+
         List<J.Annotation> annotations = mapModifiers(simpleFunction.getAnnotations(), simpleFunction.getName().asString());
 
         J.TypeParameters typeParameters = null;
@@ -2299,7 +2281,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
         JContainer<Statement> params;
         Space before = sourceBefore("(");
-        // FIXME
         params = !simpleFunction.getValueParameters().isEmpty() ?
                 JContainer.build(before, convertAllToExpressions(simpleFunction.getValueParameters(), commaDelim, t -> sourceBefore(")"), ctx), Markers.EMPTY) :
                 JContainer.build(before, singletonList(padRight(new J.Empty(randomId(), sourceBefore(")"), Markers.EMPTY), EMPTY)), Markers.EMPTY);
@@ -2347,7 +2328,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         J.Block body;
         saveCursor = cursor;
         before = whitespace();
-        // TODO: check if body is not a block.
         if (simpleFunction.getBody() instanceof FirSingleExpressionBlock) {
             if (source.startsWith("=", cursor)) {
                 skip("=");
@@ -2463,7 +2443,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     public J visitTypeAlias(FirTypeAlias typeAlias, ExecutionContext ctx) {
         Space prefix = whitespace();
 
-        List<J> modifiers = emptyList();
         Markers markers = Markers.EMPTY;
 
         List<J.Annotation> annotations = mapModifiers(typeAlias.getAnnotations(), "typealias");
@@ -2595,14 +2574,13 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             JRightPadded<Expression> expr = JRightPadded.build(element).withAfter(after);
 
             J clazz = visitElement(typeOperatorCall.getConversionTypeRef(), ctx);
-            J pattern = null;
             return new J.InstanceOf(
                     randomId(),
                     prefix,
                     markers,
                     expr,
                     clazz,
-                    pattern,
+                    null,
                     typeMapping.type(typeOperatorCall));
         }
     }
@@ -2698,7 +2676,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         Space prefix = whitespace();
         skip("try");
 
-        JContainer<J.Try.Resource> resources = null;
         J.Block block = (J.Block) visitElement(tryExpression.getTryBlock(), ctx);
         List<J.Try.Catch> catches = new ArrayList<>(tryExpression.getCatches().size());
         for (FirCatch aCatch : tryExpression.getCatches()) {
@@ -2711,7 +2688,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         return new J.Try(randomId(),
                 prefix,
                 Markers.EMPTY,
-                resources,
+                null,
                 block,
                 catches,
                 finally_);
@@ -2781,7 +2758,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         }
     }
 
-    // Merge visitValueParameter and visitProperty
     @Override
     public J visitValueParameter(FirValueParameter valueParameter, ExecutionContext ctx) {
         Space prefix = whitespace();
@@ -3181,7 +3157,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     public J visitConstructor(FirConstructor constructor, ExecutionContext ctx) {
         Space prefix = whitespace();
         Markers markers = Markers.EMPTY;
-        List<J> modifiers = emptyList();
+
         List<J.Annotation> annotations = mapModifiers(constructor.getAnnotations(), "constructor");
 
         JRightPadded<J.VariableDeclarations.NamedVariable> infixReceiver = null;
@@ -3208,7 +3184,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
         JContainer<Statement> params;
         Space before = sourceBefore("(");
-        // TODO fix me
         params = !constructor.getValueParameters().isEmpty() ?
                 JContainer.build(before, convertAllToExpressions(constructor.getValueParameters(), commaDelim, t -> sourceBefore(")"), ctx), Markers.EMPTY) :
                 JContainer.build(before, singletonList(padRight(new J.Empty(randomId(), sourceBefore(")"), Markers.EMPTY), EMPTY)), Markers.EMPTY);
@@ -3278,7 +3253,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         J.Block body;
         saveCursor = cursor;
         before = whitespace();
-        // TODO: confirm convert is okay for Body.
         if (constructor.getBody() instanceof FirSingleExpressionBlock) {
             if (source.startsWith("=", cursor)) {
                 skip("=");
@@ -3452,14 +3426,11 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         Markers markers = Markers.EMPTY;
 
         List<J.Modifier> modifiers = emptyList();
-        PsiElement currentNode = getCurrentPsiNode();
-        if (currentNode instanceof KtAnnotationEntry) {
-            currentNode = PsiTreeUtil.getParentOfType(currentNode, KtModifierList.class);
-        }
-
+        KtModifierList modifierList = PsiTreeUtil.findChildOfType(getPsiElement(regularClass), KtModifierList.class);
+        List<J.Annotation> leadingAnnotations = new ArrayList<>();
         List<J.Annotation> kindAnnotations = new ArrayList<>();
-        if (currentNode instanceof KtModifierList) {
-            modifiers = mapModifierList((KtModifierList) currentNode, regularClass.getAnnotations(), kindAnnotations);
+        if (modifierList != null && modifierList.getTextRange().getStartOffset() == cursor) {
+            modifiers = mapModifierList(modifierList, regularClass.getAnnotations(), leadingAnnotations, kindAnnotations);
         }
 
         ClassKind classKind = regularClass.getClassKind();
@@ -3528,7 +3499,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             }
         }
 
-        List<J.Annotation> leadingAnnotation = new ArrayList<>();
         int saveCursor = cursor;
         Space before = whitespace();
         JContainer<Statement> primaryConstructor = null;
@@ -3539,7 +3509,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 J.Annotation annotation = mapKModifierToAnnotation("internal");
                 annotation = annotation.withMarkers(annotation.getMarkers().addIfAbsent(new ExplicitInlineConstructor(randomId())));
                 annotation = annotation.withMarkers(annotation.getMarkers().addIfAbsent(new Modifier(randomId())));
-                leadingAnnotation.add(annotation);
+                leadingAnnotations.add(annotation);
                 before = whitespace();
             }
 
@@ -3547,7 +3517,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 J.Annotation annotation = new J.Annotation(randomId(), before, Markers.EMPTY, createIdentifier("constructor", regularClass), null);
                 annotation = annotation.withMarkers(annotation.getMarkers().addIfAbsent(new ExplicitInlineConstructor(randomId())));
                 annotation = annotation.withMarkers(annotation.getMarkers().addIfAbsent(new Modifier(randomId())));
-                leadingAnnotation.add(annotation);
+                leadingAnnotations.add(annotation);
                 before = whitespace();
             }
             skip("(");
@@ -3683,7 +3653,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 randomId(),
                 prefix,
                 markers,
-                leadingAnnotation,
+                leadingAnnotations,
                 modifiers,
                 kind,
                 name,
@@ -3697,6 +3667,11 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     }
 
     private List<J.Modifier> mapModifierList(KtModifierList currentNode, List<FirAnnotation> annotations, List<J.Annotation> lastAnnotations) {
+        return mapModifierList(currentNode, annotations, null, lastAnnotations);
+    }
+
+    private List<J.Modifier> mapModifierList(KtModifierList currentNode, List<FirAnnotation> annotations,
+                                             @Nullable List<J.Annotation> leadingAnnotations, List<J.Annotation> lastAnnotations) {
         Map<Integer, FirAnnotation> annotationsMap = new HashMap<>();
         for (FirAnnotation annotation : annotations) {
             annotationsMap.put(annotation.getSource().getStartOffset(), annotation);
@@ -3705,10 +3680,18 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         List<J.Modifier> modifiers = new ArrayList<>();
         List<J.Annotation> currentAnnotations = new ArrayList<>();
         Iterator<PsiElement> iterator = PsiUtilsKt.getAllChildren(currentNode).iterator();
+        boolean leading = true;
         while (iterator.hasNext()) {
             PsiElement it = iterator.next();
             if (it instanceof LeafPsiElement && it.getNode().getElementType() instanceof KtModifierKeywordToken) {
                 if (isJModifier(it.getText())) {
+                    if (leading) {
+                        leading = false;
+                        if (leadingAnnotations != null && !currentAnnotations.isEmpty()) {
+                            leadingAnnotations.addAll(currentAnnotations);
+                            currentAnnotations.clear();
+                        }
+                    }
                     modifiers.add(mapToJModifier(it.getText(), currentAnnotations));
                     currentAnnotations = new ArrayList<>();
                 } else {
@@ -3840,7 +3823,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         throw new UnsupportedOperationException(generateUnsupportedMessage("FirWrappedExpression"));
     }
 
-    public J visitNoReceiverExpression(FirNoReceiverExpression noReceiverExpression, ExecutionContext ctx) {
+    public J visitNoReceiverExpression() {
         throw new UnsupportedOperationException(generateUnsupportedMessage("FirNoReceiverExpression"));
     }
 
@@ -3908,13 +3891,14 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         }
 
         int saveCursor = cursor;
-        Space prefix = whitespace();
+        whitespace();
         ASTNode node = nodes.get(cursor);
+        cursor = saveCursor;
         if (node != null) {
             switch (node.getElementType().getDebugName()) {
                 case "PARENTHESIZED":
                     if (node.getTextRange().getEndOffset() >= firElement.getSource().getEndOffset()) {
-                        return wrapInParens(firElement, prefix, ctx);
+                        return wrapInParens(firElement, ctx);
                     }
                     break;
                 case "REFERENCE_EXPRESSION":
@@ -3932,7 +3916,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             }
         }
 
-        cursor = saveCursor;
         // FIR error elements
         if (firElement instanceof FirErrorNamedReference) {
             return visitErrorNamedReference((FirErrorNamedReference) firElement, ctx);
@@ -4154,15 +4137,15 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         } else if (firElement instanceof FirWrappedExpression) {
             return visitWrappedExpression((FirWrappedExpression) firElement, ctx);
         } else if (firElement instanceof FirNoReceiverExpression) {
-            return visitNoReceiverExpression((FirNoReceiverExpression) firElement, ctx);
+            return visitNoReceiverExpression();
         }
 
         throw new IllegalArgumentException("Unsupported FirElement " + firElement.getClass().getName());
     }
 
     @SuppressWarnings("unchecked")
-    private <J2 extends J> J wrapInParens(FirElement firElement, Space prefix, ExecutionContext ctx) {
-        skip("(");
+    private <J2 extends J> J wrapInParens(FirElement firElement, ExecutionContext ctx) {
+        Space prefix = sourceBefore("(");
         return new J.Parentheses<>(
                 randomId(),
                 prefix,
@@ -4349,12 +4332,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
         FirProperty loopCondition = (FirProperty) firBlock.getStatements().get(0);
         Expression expression;
-        if (loopCondition.getInitializer() instanceof FirFunctionCall &&
-                ((FirFunctionCall) loopCondition.getInitializer()).getExplicitReceiver() instanceof FirFunctionCall) {
-            expression = convertToExpression(((FirFunctionCall) loopCondition.getInitializer()).getExplicitReceiver(), ctx);
-        } else {
-            expression = convertToExpression(((FirFunctionCall) loopCondition.getInitializer()).getExplicitReceiver(), ctx);
-        }
+        expression = convertToExpression(((FirFunctionCall) loopCondition.getInitializer()).getExplicitReceiver(), ctx);
 
         Space afterExpression = sourceBefore(")");
         J.ForEachLoop.Control control = new J.ForEachLoop.Control(
@@ -4606,7 +4584,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     }
 
     private final Function<FirElement, Space> commaDelim = ignored -> sourceBefore(",");
-    private final Function<FirElement, Space> noDelim = ignored -> EMPTY;
 
     private void skip(@Nullable String token) {
         if (token != null && source.startsWith(token, cursor)) {
@@ -4627,12 +4604,8 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         return t.getSource().getEndOffset();
     }
 
-    @Nullable
-    private PsiElement getCurrentPsiNode() {
-        if (nodes.containsKey(cursor)) {
-            return nodes.get(cursor).getPsi();
-        }
-        return null;
+    private PsiElement getPsiElement(FirElement element) {
+        return element.getSource() == null ? null : ((KtRealPsiSourceElement) element.getSource()).getPsi();
     }
 
     @SuppressWarnings("unchecked")
@@ -4739,10 +4712,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
     }
 
     private int positionOfNext(String untilDelim) {
-        return positionOfNext(untilDelim, null);
-    }
-
-    private int positionOfNext(String untilDelim, @Nullable Character stop) {
         boolean inMultiLineComment = false;
         boolean inSingleLineComment = false;
 
@@ -4773,10 +4742,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
                 }
 
                 if (!inMultiLineComment && !inSingleLineComment) {
-                    if (stop != null && source.charAt(delimIndex) == stop) {
-                        return -1;
-                    } // reached stop word before finding the delimiter
-
                     if (source.startsWith(untilDelim, delimIndex)) {
                         break; // found it!
                     }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinSource.java
@@ -18,14 +18,12 @@ package org.openrewrite.kotlin.internal;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode;
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement;
 import org.jetbrains.kotlin.com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.kotlin.com.intellij.psi.PsiFile;
 import org.jetbrains.kotlin.fir.declarations.FirFile;
 import org.jetbrains.kotlin.psi.KtElement;
-import org.jetbrains.kotlin.psi.psiUtil.PsiUtilsKt;
+import org.jetbrains.kotlin.psi.KtFile;
 import org.openrewrite.Parser;
 
 import java.util.*;
@@ -34,23 +32,18 @@ import java.util.*;
 public class KotlinSource {
     Parser.Input input;
     Map<Integer, ASTNode> nodes;
-//    Map<Integer, Map<Class<? extends PsiElement>, ASTNode>> nodesMap;
 
     @Setter
     FirFile firFile;
 
     public KotlinSource(Parser.Input input,
-                        @Nullable PsiFile psiFile) {
+                        KtFile ktFile) {
         this.input = input;
-        this.nodes = map(psiFile);
-//        this.nodesMap = mapNodes(psiFile);
+        this.nodes = map(ktFile);
     }
 
-    private Map<Integer, ASTNode> map(@Nullable PsiFile psiFile) {
+    private Map<Integer, ASTNode> map(KtFile ktFile) {
         Map<Integer, ASTNode> result = new LinkedHashMap<>();
-        if (psiFile == null) {
-            return result;
-        }
 
         Set<PsiElement> visited = Collections.newSetFromMap(new IdentityHashMap<>());
         PsiElementVisitor v = new PsiElementVisitor() {
@@ -73,43 +66,7 @@ public class KotlinSource {
                 }
             }
         };
-        v.visitElement(psiFile);
-        return result;
-    }
-
-    // TODO: assess whether this is a better way to map nodes.
-    // The cursor positions on the FIR source will be out of sync with the source and PSI source when
-    // there are multiple CRLF end of lines and/or other elements that the compiler removes during desugaring.
-    private Map<Integer, Map<Class<? extends PsiElement>, ASTNode>> mapNodes(@Nullable PsiFile psiFile) {
-        Map<Integer, Map<Class<? extends PsiElement>, ASTNode>> result = new LinkedHashMap<>();
-        if (psiFile == null) {
-            return result;
-        }
-
-        Set<PsiElement> visited = Collections.newSetFromMap(new IdentityHashMap<>());
-        PsiElementVisitor v = new PsiElementVisitor() {
-            @Override
-            public void visitElement(@NotNull PsiElement element) {
-                if (!visited.add(element)) {
-                    return;
-                }
-
-                result.compute(element.getTextRange().getStartOffset(), (k, v) -> {
-                    if (v == null) {
-                        v = new IdentityHashMap<>();
-                    }
-                        v.put(element.getClass(), element.getNode());
-                    return v;
-                });
-
-                Iterator<PsiElement> iterator = PsiUtilsKt.getAllChildren(element).iterator();
-                while (iterator.hasNext()) {
-                    PsiElement child = iterator.next();
-                    visitElement(child);
-                }
-            }
-        };
-        v.visitElement(psiFile);
+        v.visitElement(ktFile);
         return result;
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
@@ -303,7 +303,7 @@ class BinaryTest implements RewriteTest {
           kotlin(
             """
               data class Foo ( val aliases : List < String > ) {
-                  fun names ( ) = listOf ( canonicalName ) + aliases
+                  fun names ( ) = listOf ( "canonicalName" ) + aliases
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -22,8 +22,20 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
-@SuppressWarnings({"RemoveEmptyClassBody", "RedundantVisibilityModifier", "SortModifiers", "ClassName"})
+@SuppressWarnings("ALL")
 class ClassDeclarationTest implements RewriteTest {
+
+    @Test
+    void crlf() {
+        rewriteRun(
+          kotlin(
+            new StringBuilder()
+              .append("package some.other.name\r\n")
+              .append("class A { }\r\n")
+              .append("class B { }").toString()
+          )
+        );
+    }
 
     @Test
     void multipleClassDeclarationsInOneCompilationUnit() {
@@ -132,11 +144,11 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
               public @Deprecated ( "message 0" ) abstract @Suppress("") class Test
-                          
+              
               @Deprecated ( "message 1" )
               @Suppress ( "" )
               class A
-                          
+              
               @Suppress ( "unused" , "unchecked" )
               @Deprecated ( "message 2" )
               class B
@@ -166,7 +178,7 @@ class ClassDeclarationTest implements RewriteTest {
             """
               interface A
               interface B
-                          
+              
               class KotlinTypeGoat < T : A , S : B>
               """
           )
@@ -233,7 +245,7 @@ class ClassDeclarationTest implements RewriteTest {
               interface B
               interface C
               interface D
-                          
+              
               class KotlinTypeGoat < T , S > where S : A , T : D , S : B , T : C
               """
           )
@@ -277,10 +289,10 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
               sealed class InvalidField {
-                abstract val field : String
+                  abstract val field : String
               }
               data class InvalidEmail ( val errors : List < String > ) : InvalidField ( ) {
-                override val field : String = "email"
+                  override val field : String = "email"
               }
               """
           )
@@ -294,10 +306,10 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
               sealed interface InvalidField {
-                val field : String
+                  val field : String
               }
               data class InvalidEmail ( val errors : List < String > ) : InvalidField {
-                override val field : String = "email"
+                  override val field : String = "email"
               }
               """
           )
@@ -310,10 +322,10 @@ class ClassDeclarationTest implements RewriteTest {
           kotlin(
             """
               sealed interface InvalidField {
-                val field : String
+                  val field : String
               }
               object InvalidEmail : InvalidField {
-                override val field : String = "email"
+                  override val field : String = "email"
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -269,7 +269,7 @@ class VariableDeclarationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/84")
     @Test
-    void unresolvedNameInLightSource() {
+    void unresolvedNameFirSource() {
         rewriteRun(
           kotlin(
             """


### PR DESCRIPTION
Changes:

- FirElements are backed with RealPsiElements rather than LightTreeElements.
- CRLF does not cause the start offsets in FirElement sources to become out of sync with the source code.

fixes #187
