### PR TITLE
Visit whitespace stored in markers and pass in location.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/package-info.java
+++ b/src/main/java/org/openrewrite/kotlin/format/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.kotlin.format;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1435,7 +1435,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
 
                 break;
             case "get":
-                // TODO: Check if the function call may be safely changed to a J.ArrayAccess. Note: must cover not null checks: `!!`.
                 left = convertToExpression(functionCall.getExplicitReceiver(), ctx);
 
                 opPrefix = sourceBefore("[");
@@ -2135,10 +2134,11 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             }
             J j = visitElement(resolvedTypeRef.getDelegatedTypeRef(), ctx);
             JavaType type = typeMapping.type(resolvedTypeRef);
+            if (j instanceof TypeTree) {
+                j = ((TypeTree) j).withType(type);
+            }
             if (j instanceof J.Identifier) {
                 j = ((J.Identifier) j).withAnnotations(annotations);
-            } else if (j instanceof TypeTree) {
-                j = ((TypeTree) j).withType(type);
             }
 
             if (j instanceof J.ParameterizedType) {
@@ -2775,7 +2775,6 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             lastAnnotations = null;
         }
 
-        Space namePrefix = EMPTY;
         String valueName = "";
         if ("<unused var>".equals(valueParameter.getName().toString())) {
             valueName = "_";
@@ -2825,7 +2824,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         JRightPadded<J.VariableDeclarations.NamedVariable> namedVariable = maybeSemicolon(
                 new J.VariableDeclarations.NamedVariable(
                         randomId(),
-                        namePrefix,
+                        EMPTY,
                         Markers.EMPTY,
                         name,
                         emptyList(),

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.kotlin.internal;
 
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.Tree;
@@ -105,8 +106,8 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         visitSpace(binary.getAfter(), KSpace.Location.BINARY_SUFFIX, p);
         if (binary.getOperator() == K.Binary.Type.Get) {
             p.append("]");
-            trailingMarkers(binary.getMarkers(), p);
         }
+        trailingMarkers(binary.getMarkers(), p);
         afterSyntax(binary, p);
         return binary;
     }
@@ -264,16 +265,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             }
 
             if (nv.getInitializer() != null) {
-                String equals = "=";
-                for (Marker marker : vd.getMarkers().getMarkers()) {
-                    if (marker instanceof By) {
-                        equals = "by";
-                        break;
-                    } else if (marker instanceof OmitEquals) {
-                        equals = "";
-                        break;
-                    }
-                }
+                String equals = getEqualsText(vd);
 
                 visitSpace(Objects.requireNonNull(nv.getPadding().getInitializer()).getBefore(), Space.Location.VARIABLE_INITIALIZER, p);
                 p.append(equals);
@@ -971,16 +963,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                 }
 
                 if (variable.getElement().getInitializer() != null) {
-                    String equals = "=";
-                    for (Marker marker : multiVariable.getMarkers().getMarkers()) {
-                        if (marker instanceof By) {
-                            equals = "by";
-                            break;
-                        } else if (marker instanceof OmitEquals) {
-                            equals = "";
-                            break;
-                        }
-                    }
+                    String equals = getEqualsText(multiVariable);
 
                     visitSpace(Objects.requireNonNull(variable.getElement().getPadding().getInitializer()).getBefore(), Space.Location.VARIABLE_INITIALIZER, p);
                     p.append(equals);
@@ -1163,7 +1146,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         if (loc != null) {
             visitSpace(prefix, loc, p);
         }
-        visitMarkers(markers, p);
+        KotlinPrinter.this.visitMarkers(markers, p);
         for (Marker marker : markers.getMarkers()) {
             p.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(getCursor(), marker), JAVA_MARKER_WRAPPER));
         }
@@ -1180,7 +1163,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         if (loc != null) {
             delegate.visitSpace(prefix, loc, p);
         }
-        visitMarkers(markers, p);
+        KotlinPrinter.this.visitMarkers(markers, p);
         for (Marker marker : markers.getMarkers()) {
             p.append(p.getMarkerPrinter().beforeSyntax(marker, new Cursor(getCursor(), marker), JAVA_MARKER_WRAPPER));
         }
@@ -1194,5 +1177,20 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         for (Marker marker : markers.getMarkers()) {
             p.append(p.getMarkerPrinter().afterSyntax(marker, new Cursor(getCursor(), marker), JAVA_MARKER_WRAPPER));
         }
+    }
+
+    @NotNull
+    private static String getEqualsText(J.VariableDeclarations vd) {
+        String equals = "=";
+        for (Marker marker : vd.getMarkers().getMarkers()) {
+            if (marker instanceof By) {
+                equals = "by";
+                break;
+            } else if (marker instanceof OmitEquals) {
+                equals = "";
+                break;
+            }
+        }
+        return equals;
     }
 }

--- a/src/main/java/org/openrewrite/kotlin/marker/AnnotationCallSite.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/AnnotationCallSite.java
@@ -17,15 +17,11 @@ package org.openrewrite.kotlin.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.Incubating;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
-// Ideally, the Space will exist on the AST.
-// For now, we're using a marker to represent whitespace that exists in Kotlin and does not fit into `J`.
-@Incubating(since = "0.0")
 @Value
 @With
 public class AnnotationCallSite implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/marker/CheckNotNull.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/CheckNotNull.java
@@ -17,15 +17,11 @@ package org.openrewrite.kotlin.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.Incubating;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
-// Ideally, the Space will exist on the AST.
-// For now, we're using a marker to represent whitespace that exists in Kotlin and does not fit into `J`.
-@Incubating(since = "0.0")
 @Value
 @With
 public class CheckNotNull implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/marker/Extension.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/Extension.java
@@ -23,6 +23,6 @@ import java.util.UUID;
 
 @Value
 @With
-public class ReceiverType implements Marker {
+public class Extension implements Marker {
     UUID id;
 }

--- a/src/main/java/org/openrewrite/kotlin/marker/GenericType.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/GenericType.java
@@ -17,14 +17,19 @@ package org.openrewrite.kotlin.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
 @Value
 @With
-public class KObject implements Marker {
+public class GenericType implements Marker {
     UUID id;
-    Space prefix;
+    Variance variance;
+
+    public enum Variance {
+        INVARIANT,
+        COVARIANT,
+        CONTRAVARIANT
+    }
 }

--- a/src/main/java/org/openrewrite/kotlin/marker/IsNullSafe.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/IsNullSafe.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 
 @Value
 @With
-public class KObject implements Marker {
+public class IsNullSafe implements Marker {
     UUID id;
     Space prefix;
 }

--- a/src/main/java/org/openrewrite/kotlin/marker/IsNullable.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/IsNullable.java
@@ -17,15 +17,11 @@ package org.openrewrite.kotlin.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.Incubating;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
-// Ideally, the Space will exist on the AST.
-// For now, we're using a marker to represent whitespace that exists in Kotlin and does not fit into `J`.
-@Incubating(since = "0.0")
 @Value
 @With
 public class IsNullable implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/marker/SpreadArgument.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/SpreadArgument.java
@@ -17,15 +17,11 @@ package org.openrewrite.kotlin.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.Incubating;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
-// Ideally, the Space will exist on the AST.
-// For now, we're using a marker to represent whitespace that exists in Kotlin and does not fit into `J`.
-@Incubating(since = "0.0")
 @Value
 @With
 public class SpreadArgument implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/marker/TypeReferencePrefix.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/TypeReferencePrefix.java
@@ -17,15 +17,11 @@ package org.openrewrite.kotlin.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.Incubating;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
-// Ideally, the Space will exist on the AST.
-// For now, we're using a marker to represent whitespace that exists in Kotlin and does not fit into `J`.
-@Incubating(since = "0.0")
 @Value
 @With
 public class TypeReferencePrefix implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -571,6 +571,9 @@ public interface K extends J {
         UUID id;
 
         @With
+        List<J.Annotation> annotations;
+
+        @With
         J.Return expression;
 
         @With

--- a/src/main/java/org/openrewrite/kotlin/tree/KSpace.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/KSpace.java
@@ -17,7 +17,7 @@ package org.openrewrite.kotlin.tree;
 
 public class KSpace {
     public enum Location {
-        OBJECT_PREFIX,
+        ANNOTATION_CALL_SITE_PREFIX,
         BINARY_PREFIX,
         BINARY_OPERATOR,
         BINARY_SUFFIX,
@@ -29,6 +29,7 @@ public class KSpace {
         FUNCTION_TYPE_PREFIX,
         FUNCTION_TYPE_RECEIVER,
         IS_NULLABLE_PREFIX,
+        IS_NULL_SAFE_PREFIX,
         KRETURN_PREFIX,
         KSTRING_PREFIX,
         KSTRING_SUFFIX,
@@ -39,6 +40,7 @@ public class KSpace {
         LIST_LITERAL_ELEMENTS,
         LIST_LITERAL_ELEMENT_SUFFIX,
         NAMED_VARIABLE_INITIALIZER_PREFIX,
+        OBJECT_PREFIX,
         PROPERTY_PREFIX,
         SPREAD_ARGUMENT_PREFIX,
         TOP_LEVEL_STATEMENT,

--- a/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.tree.KSpace;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class SpacesTest implements RewriteTest {
+
+    // This test ensures spaces stored in markers are visited and may be removed once the SpacesVisitor and tests are implemented.
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/192")
+    @SuppressWarnings("RedundantNullableReturnType")
+    @Test
+    void visitsMarkerLocation() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public Space visitSpace(Space space, KSpace.Location loc, ExecutionContext executionContext) {
+                  if (!space.getComments().isEmpty()) {
+                      return space;
+                  }
+                  if (loc == KSpace.Location.TYPE_REFERENCE_PREFIX || loc == KSpace.Location.IS_NULLABLE_PREFIX || loc == KSpace.Location.CHECK_NOT_NULL_PREFIX) {
+                      return space.withComments(ListUtils.concat(new TextComment(true, loc.name(), "", Markers.EMPTY), space.getComments()));
+                  }
+                  return super.visitSpace(space, loc, executionContext);
+              }
+          })),
+          kotlin(
+            """
+              class A {
+                  fun method ( ) : Int ? {
+                      return 1
+                  }
+              }
+              """,
+            """
+              class A {
+                  fun method ( ) /*TYPE_REFERENCE_PREFIX*/: Int /*IS_NULLABLE_PREFIX*/? {
+                      return 1
+                  }
+              }
+              """
+          ),
+          kotlin(
+            """
+              val a = A ( )
+              val b = a . method ( ) !!
+              val c = b !!
+              """,
+            """
+              val a = A ( )
+              val b = a . method ( ) /*CHECK_NOT_NULL_PREFIX*/!!
+              val c = b /*CHECK_NOT_NULL_PREFIX*/!!
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -15,7 +15,7 @@
  */
 package org.openrewrite.kotlin.tree;
 
-import org.junit.jupiter.api.Disabled;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
@@ -24,6 +24,30 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings({"RedundantSuppression", "RedundantNullableReturnType", "RedundantVisibilityModifier", "UnusedReceiverParameter", "SortModifiers"})
 class AnnotationTest implements RewriteTest {
+
+    @Language("kotlin")
+    private static final String ANNOTATION =
+            """
+              @Target(
+                  AnnotationTarget.CLASS,
+                  AnnotationTarget.ANNOTATION_CLASS,
+                  AnnotationTarget.TYPE_PARAMETER,
+                  AnnotationTarget.PROPERTY,
+                  AnnotationTarget.FIELD,
+                  AnnotationTarget.LOCAL_VARIABLE,
+                  AnnotationTarget.VALUE_PARAMETER,
+                  AnnotationTarget.CONSTRUCTOR,
+                  AnnotationTarget.FUNCTION,
+                  AnnotationTarget.PROPERTY_GETTER,
+                  AnnotationTarget.PROPERTY_SETTER,
+                  AnnotationTarget.TYPE,
+                  AnnotationTarget.EXPRESSION,
+                  AnnotationTarget.FILE,
+                  AnnotationTarget.TYPEALIAS
+              )
+              @Retention(AnnotationRetention.SOURCE)
+              annotation class Ann
+              """;
 
     @Test
     void fileScope() {
@@ -41,14 +65,12 @@ class AnnotationTest implements RewriteTest {
     @Test
     void multipleFileScope() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              @file : A ( "1" )
-              @file : A ( "2" )
-              @file : A ( "3" )
-
-              @Repeatable
-              annotation class A ( val s : String )
+              @file : Ann
+              @file : Ann
+              @file : Ann
               """
           )
         );
@@ -73,8 +95,7 @@ class AnnotationTest implements RewriteTest {
             """
               @Target ( AnnotationTarget . LOCAL_VARIABLE )
               @Retention ( AnnotationRetention . SOURCE )
-              annotation class Test ( val values : Array < String > ) {
-              }
+              annotation class Test ( val values : Array < String > )
               """
           ),
           kotlin(
@@ -105,13 +126,12 @@ class AnnotationTest implements RewriteTest {
     @Test
     void annotationUseSiteTargetAnnotationOnly() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              @Repeatable
-              annotation class A (val s : String)
               class TestA {
-                  @get : A ( "1" )
-                  @set : A ( "2" )
+                  @get : Ann
+                  @set : Ann
                   var name : String = ""
               }
               """
@@ -123,16 +143,13 @@ class AnnotationTest implements RewriteTest {
     @Test
     void annotationUseSiteTarget() {
         rewriteRun(
-          kotlin("""
-              @Repeatable
-              annotation class A ( val s : String )
-          """),
+          kotlin(ANNOTATION),
           kotlin(
             """
               class TestA {
-                  @get : A ( "1" )
+                  @get : Ann
                   public
-                  @set : A ( "2" )
+                  @set : Ann
                   var name: String = ""
               }
               """
@@ -141,8 +158,8 @@ class AnnotationTest implements RewriteTest {
             """
               class TestB {
                   public
-                  @get : A ( "1" )
-                  @set : A ( "2" )
+                  @get : Ann
+                  @set : Ann
                   var name : String = ""
               }
               """
@@ -154,9 +171,9 @@ class AnnotationTest implements RewriteTest {
     @Test
     void constructorParameterWithAnnotation() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              annotation class Ann
               class Example(
                   @get : Ann
                   val bar : String
@@ -170,10 +187,10 @@ class AnnotationTest implements RewriteTest {
     @Test
     void getUseSiteOnConstructorParams() {
         rewriteRun(
-          kotlin("@Repeatable annotation class A"),
+          kotlin(ANNOTATION),
           kotlin(
             """
-              class Example ( /**/  /**/ @get : A /**/ /**/ @set : A /**/ /**/ var foo: String , @get : A val bar: String )
+              class Example ( /**/  /**/ @get : Ann /**/ /**/ @set : Ann /**/ /**/ var foo: String , @get : Ann val bar: String )
               """
           )
         );
@@ -182,16 +199,16 @@ class AnnotationTest implements RewriteTest {
     @Test
     void annotationOnExplicitGetter() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              annotation class A
               class Test {
                   public var stringRepresentation : String = ""
-                      @A
+                      @Ann
                       // comment
                       get ( ) = field
 
-                      @A
+                      @Ann
                       set ( value ) {
                           field = value
                       }
@@ -204,9 +221,9 @@ class AnnotationTest implements RewriteTest {
     @Test
     void conditionalParameter() {
         rewriteRun(
+          kotlin("annotation class A ( val s : String )"),
           kotlin(
             """
-              annotation class A ( val s : String )
               @A ( if ( true ) "1" else "2" )
               class Test
               """
@@ -217,9 +234,9 @@ class AnnotationTest implements RewriteTest {
     @Test
     void paramAnnotation() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              annotation class Ann
               class Example ( @param : Ann val quux : String )
               """
           )
@@ -229,23 +246,22 @@ class AnnotationTest implements RewriteTest {
     @Test
     void fieldAnnotation() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              annotation class Ann
               class Example ( @field : Ann val foo : String )
               """
           )
         );
     }
 
-    @Disabled
     @Test
     void receiverAnnotationUseSiteTarget() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              annotation class Ann
-              fun @receiver : Ann String.myExtension() { }
+              fun @receiver : Ann String . myExtension ( ) { }
               """
           )
         );
@@ -254,11 +270,11 @@ class AnnotationTest implements RewriteTest {
     @Test
     void setParamAnnotationUseSiteTarget() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              annotation class A
               class Example {
-                  @setparam : A
+                  @setparam : Ann
                   var name: String = ""
               }
               """
@@ -269,15 +285,38 @@ class AnnotationTest implements RewriteTest {
     @Test
     void destructuringVariableDeclaration() {
         rewriteRun(
+          kotlin(ANNOTATION),
           kotlin(
             """
-              annotation class A
               fun example ( ) {
-                val ( @A a , @A b , @A c ) = Triple ( 1 , 2 , 3 )
+                val ( @Ann a , @Ann b , @Ann c ) = Triple ( 1 , 2 , 3 )
               }
               """
           )
         );
     }
 
+    @Test
+    void annotationsInManyLocations() {
+        rewriteRun(
+          kotlin(ANNOTATION),
+          kotlin(
+            """
+              @Ann
+              open class Test < @Ann in Number > ( @Ann val s : String ) {
+                  @Ann var n : Int = 42
+                      @Ann get ( ) = 42
+                      @Ann set ( @Ann value ) {
+                          field = value
+                      }
+              
+                  @Ann inline fun < @Ann reified T > m ( @Ann s : @Ann String ) : String {
+                      @Ann return s
+                  }
+              }
+              @Ann typealias Other = @Ann String
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Changes:
- In preparation for auto-formatting, markers that store whitespace are automatically visited and pass in the corresponding KSpace.Location to `visitSpace`.
- Added support for receiver use-site annotations.
- Polished detection of constant expressions that only contain whitespace by using the PSI.
- Added support for annotations before `ReturnExpression`.
- Added support for annotations before `ResolvedTypeRef`
- Added `IsNullSafe` marker.
- Renamed `ReceiverType` to `Extension`

fixes #192 