### PR TITLE
Call `requirePrintEqualsInput` from `KotlinParser#parseInputs`

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -161,10 +161,10 @@ public class KotlinParser implements Parser {
         FirSession firSession = compilerCus.getFirSession();
         return Stream.concat(
                         compilerCus.getSources().stream()
-                                .map(compiled -> {
+                                .map(kotlinSource -> {
                                     try {
                                         KotlinParserVisitor mappingVisitor = new KotlinParserVisitor(
-                                                compiled,
+                                                kotlinSource,
                                                 relativeTo,
                                                 styles,
                                                 typeCache,
@@ -172,12 +172,12 @@ public class KotlinParser implements Parser {
                                                 ctx
                                         );
 
-                                        SourceFile kcu = (SourceFile) mappingVisitor.visitFile(compiled.getFirFile(), new InMemoryExecutionContext());
-                                        parsingListener.parsed(compiled.getInput(), kcu);
-                                        return kcu;
+                                        SourceFile kcu = (SourceFile) mappingVisitor.visitFile(kotlinSource.getFirFile(), new InMemoryExecutionContext());
+                                        parsingListener.parsed(kotlinSource.getInput(), kcu);
+                                        return requirePrintEqualsInput(kcu, kotlinSource.getInput(), relativeTo, ctx);
                                     } catch (Throwable t) {
                                         ctx.getOnError().accept(t);
-                                        return ParseError.build(this, compiled.getInput(), relativeTo, ctx, t);
+                                        return ParseError.build(this, kotlinSource.getInput(), relativeTo, ctx, t);
                                     }
                                 }),
                         Stream.generate(() -> {


### PR DESCRIPTION
## What's changed?
Call `requirePrintEqualsInput` from `PythonParser#parseInputs`

## What's your motivation?
Consistency with other parsers, and prevents accidental file modifications.

## Any additional context
Depends on https://github.com/openrewrite/rewrite/pull/3459