### PR TITLE
Fix leading annotation parsing

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/BlankLinesVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/BlankLinesVisitor.java
@@ -273,13 +273,13 @@ public class BlankLinesVisitor<P> extends KotlinIsoVisitor<P> {
                     return minimumLines(m, style.getMinimum().getBeforeDeclarationWithCommentOrAnnotation());
                 }
 
-                if (hasAnnotation(m)) {
+                if (!m.getLeadingAnnotations().isEmpty()) {
                     return minimumLines(m, style.getMinimum().getBeforeDeclarationWithCommentOrAnnotation());
                 }
             } else if (statement instanceof J.VariableDeclarations) {
                 J.VariableDeclarations v = (J.VariableDeclarations) statement;
 
-                if (hasAnnotation(v)) {
+                if (!v.getLeadingAnnotations().isEmpty()) {
                     return minimumLines(v, style.getMinimum().getBeforeDeclarationWithCommentOrAnnotation());
                 }
             }
@@ -388,28 +388,6 @@ public class BlankLinesVisitor<P> extends KotlinIsoVisitor<P> {
             }
         }
         return newLineCount;
-    }
-
-    public static boolean hasAnnotation(J.MethodDeclaration m) {
-        boolean hasAnnotation = false;
-        for (J.Modifier mod: m.getModifiers()) {
-            if (!mod.getAnnotations().isEmpty()) {
-                hasAnnotation = true;
-                break;
-            }
-        }
-        return hasAnnotation;
-    }
-
-    public static boolean hasAnnotation(J.VariableDeclarations v) {
-        boolean hasAnnotation = false;
-        for (J.Modifier mod: v.getModifiers()) {
-            if (!mod.getAnnotations().isEmpty()) {
-                hasAnnotation = true;
-                break;
-            }
-        }
-        return hasAnnotation;
     }
 
     @Nullable

--- a/src/main/java/org/openrewrite/kotlin/format/WrappingAndBracesVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/WrappingAndBracesVisitor.java
@@ -170,7 +170,15 @@ public class WrappingAndBracesVisitor<P> extends KotlinIsoVisitor<P> {
         }
 
         if (!c.getLeadingAnnotations().isEmpty()) {
-            if (!c.getModifiers().isEmpty()) {
+            boolean hasModifier = false;
+            for (J.Modifier mod : c.getModifiers()) {
+                if (mod.getType() != J.Modifier.Type.Final) {
+                    hasModifier = true;
+                    break;
+                }
+            }
+
+            if (hasModifier) {
                 c = c.withModifiers(withNewline(c.getModifiers()));
             } else {
                 J.ClassDeclaration.Kind kind = c.getAnnotations().getKind();
@@ -180,7 +188,6 @@ public class WrappingAndBracesVisitor<P> extends KotlinIsoVisitor<P> {
                     ));
                 }
             }
-
         }
         return c;
     }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinParserVisitor.java
@@ -1171,7 +1171,7 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
             PsiElement propNode = getRealPsiElement(property);
             KtModifierList modifierListVar = getModifierList(propNode);
             if (modifierListVar != null) {
-                mapModifierList(modifierListVar, property.getAnnotations(), emptyList(), annotations);
+                mapModifierList(modifierListVar, property.getAnnotations(), annotations, emptyList());
             }
             JavaType.Variable vt = (JavaType.Variable) typeMapping.type(property, getCurrentFile());
             J.Identifier nameVar = createIdentifier(entry.getName(), vt.getType(), vt).withAnnotations(annotations);
@@ -3790,7 +3790,11 @@ public class KotlinParserVisitor extends FirDefaultVisitor<J, ExecutionContext> 
         }
 
         if (!currentAnnotations.isEmpty()) {
-            lastAnnotations.addAll(currentAnnotations);
+            if (leading) {
+                leadingAnnotations.addAll(currentAnnotations);
+            } else {
+                lastAnnotations.addAll(currentAnnotations);
+            }
         }
 
         return modifiers;

--- a/src/test/java/org/openrewrite/kotlin/format/WrappingAndBracesTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/WrappingAndBracesTest.java
@@ -361,7 +361,15 @@ class WrappingAndBracesTest implements RewriteTest {
                       @Suppress("ALL") var foo: Int
                   }
               }
-              """
+              """,
+            """
+              class Test {
+                  public fun doSomething() {
+                      @Suppress("ALL")
+               var foo: Int
+                  }
+              }
+"""
           )
         );
     }

--- a/src/test/java/org/openrewrite/kotlin/format/WrappingAndBracesTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/WrappingAndBracesTest.java
@@ -369,7 +369,7 @@ class WrappingAndBracesTest implements RewriteTest {
                var foo: Int
                   }
               }
-"""
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -18,9 +18,11 @@ package org.openrewrite.kotlin.tree;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings({"RedundantSuppression", "RedundantNullableReturnType", "RedundantVisibilityModifier", "UnusedReceiverParameter", "SortModifiers"})
@@ -86,6 +88,25 @@ class AnnotationTest implements RewriteTest {
               @SuppressWarnings ( "ConstantConditions" , "unchecked" )
               class A
               """
+          )
+        );
+    }
+
+    @Test
+    void leadingAnnotation() {
+        rewriteRun(
+          kotlin(
+            """
+              annotation class Anno
+              class Test {
+                  @Anno
+                  val id: String = "1"
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.VariableDeclarations v = (J.VariableDeclarations) ((J.ClassDeclaration) cu.getStatements().get(1)).getBody().getStatements().get(0);
+                assertThat(v.getLeadingAnnotations().size()).isEqualTo(1);
+            })
           )
         );
     }

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -93,19 +93,21 @@ class AnnotationTest implements RewriteTest {
     }
 
     @Test
-    void leadingAnnotation() {
+    void leadingAnnotations() {
         rewriteRun(
           kotlin(
             """
               annotation class Anno
+              annotation class Anno2
               class Test {
                   @Anno
+                  @Anno2
                   val id: String = "1"
               }
               """,
             spec -> spec.afterRecipe(cu -> {
-                J.VariableDeclarations v = (J.VariableDeclarations) ((J.ClassDeclaration) cu.getStatements().get(1)).getBody().getStatements().get(0);
-                assertThat(v.getLeadingAnnotations().size()).isEqualTo(1);
+                J.VariableDeclarations v = (J.VariableDeclarations) ((J.ClassDeclaration) cu.getStatements().get(2)).getBody().getStatements().get(0);
+                assertThat(v.getLeadingAnnotations().size()).isEqualTo(2);
             })
           )
         );


### PR DESCRIPTION
Annotation before a declaration should be put into `leadingAnnotation` but not attached annotations in a modifier.