### PR TITLE
Add RemoveTrailingSemicolon recipe

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/cleanup/EqualsMethodUsage.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/EqualsMethodUsage.java
@@ -21,7 +21,6 @@ import lombok.With;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
@@ -65,7 +64,7 @@ public class EqualsMethodUsage extends Recipe {
     }
 
     @Override
-    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+    public Duration getEstimatedEffortPerOccurrence() {
         return Duration.ofMinutes(3);
     }
 

--- a/src/main/java/org/openrewrite/kotlin/cleanup/ImplicitParameterInLambda.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/ImplicitParameterInLambda.java
@@ -20,7 +20,6 @@ import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.kotlin.KotlinVisitor;
 
@@ -48,7 +47,7 @@ public class ImplicitParameterInLambda extends Recipe {
     }
 
     @Override
-    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+    public Duration getEstimatedEffortPerOccurrence() {
         return Duration.ofMinutes(2);
     }
 

--- a/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
@@ -129,8 +129,9 @@ public class RemoveTrailingSemicolon extends Recipe {
             return removable;
         }
 
-        CollectSemicolonRemovableElements() {
-            setDelegate(new MyKotlinJavaPrinter(this));
+        @Override
+        protected KotlinJavaPrinter<Set<Marker>> delegate() {
+            return new MyKotlinJavaPrinter(this);
         }
     }
 }

--- a/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
@@ -56,7 +56,7 @@ public class RemoveTrailingSemicolon extends Recipe {
             Set<J> semiColonRemovable;
 
             @Override
-            public K.@NotNull CompilationUnit visitCompilationUnit(K.@NotNull CompilationUnit cu,
+            public K.@NotNull CompilationUnit visitCompilationUnit(@NotNull K.CompilationUnit cu,
                                                                    @NotNull ExecutionContext ctx) {
                 semiColonRemovable = new HashSet<>();
                 CollectSemicolonRemovableElements.collect(cu.print(getCursor()), cu, semiColonRemovable);
@@ -107,7 +107,7 @@ public class RemoveTrailingSemicolon extends Recipe {
         }
 
         @Override
-        public @NotNull J visitVariableDeclarations(J.@NotNull VariableDeclarations multiVariable,
+        public @NotNull J visitVariableDeclarations(@NotNull J.VariableDeclarations multiVariable,
                                                     @NotNull PrintOutputCapture<Set<J>> p) {
             J mv = super.visitVariableDeclarations(multiVariable, p);
             if (startsWithNewLineAfterOffset(sourceCode, p.out.length())) {
@@ -119,7 +119,7 @@ public class RemoveTrailingSemicolon extends Recipe {
         }
 
         @Override
-        public @NotNull J visitMethodInvocation(J.@NotNull MethodInvocation method, @NotNull PrintOutputCapture<Set<J>> p) {
+        public @NotNull J visitMethodInvocation(@NotNull J.MethodInvocation method, @NotNull PrintOutputCapture<Set<J>> p) {
             J m = super.visitMethodInvocation(method, p);
 
             if (startsWithNewLineAfterOffset(sourceCode, p.out.length())) {
@@ -130,7 +130,7 @@ public class RemoveTrailingSemicolon extends Recipe {
         }
 
         @Override
-        public @NotNull J visitBlock(J.@NotNull Block block, @NotNull PrintOutputCapture<Set<J>> p) {
+        public @NotNull J visitBlock(@NotNull J.Block block, @NotNull PrintOutputCapture<Set<J>> p) {
             J.Block b = (J.Block) super.visitBlock(block, p);
 
             b = b.getPadding().withStatements(ListUtils.map(b.getPadding().getStatements(), rp -> {

--- a/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.cleanup;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.PrintOutputCapture;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.internal.KotlinPrinter;
+import org.openrewrite.kotlin.marker.Semicolon;
+import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.marker.Markers;
+
+import java.util.*;
+
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class RemoveTrailingSemicolon extends Recipe {
+    @Override
+    public @NotNull String getDisplayName() {
+        return "Remove unnecessary trailing semicolon";
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return "Some Java programmers may mistakenly add semicolons at the end when writing Kotlin code, but in " +
+               "reality, they are not necessary.";
+    }
+
+    @Override
+    public @NotNull TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new KotlinIsoVisitor<ExecutionContext>() {
+            Set<J> semiColonRemovable;
+
+            @Override
+            public K.@NotNull CompilationUnit visitCompilationUnit(K.@NotNull CompilationUnit cu,
+                                                                   @NotNull ExecutionContext ctx) {
+                semiColonRemovable = new HashSet<>();
+                CollectSemicolonRemovableElements.collect(cu.print(getCursor()), cu, semiColonRemovable);
+                cu = cu.getPadding().withImports(removeSemiColon(cu.getPadding().getImports()));
+                return super.visitCompilationUnit(cu, ctx);
+            }
+
+            @Override
+            public <T> @NotNull JRightPadded<T> visitRightPadded(@Nullable JRightPadded<T> right,
+                                                                 @NotNull JRightPadded.Location loc,
+                                                                 @NotNull ExecutionContext ctx) {
+                right = super.visitRightPadded(right, loc, ctx);
+
+                if (right.getElement() instanceof J && !semiColonRemovable.contains(right.getElement())) {
+                    return right;
+                }
+
+                Markers markers = right.getMarkers();
+                markers = markers.withMarkers(ListUtils.map(markers.getMarkers(), marker ->
+                        marker instanceof Semicolon ? null : marker
+                ));
+
+                return right.withMarkers(markers);
+            }
+
+        };
+    }
+
+
+    private static <T> List<JRightPadded<T>> removeSemiColon(List<JRightPadded<T>> rps) {
+        return ListUtils.map(rps, RemoveTrailingSemicolon::removeSemiColon);
+    }
+
+    private static<T> JRightPadded<T> removeSemiColon(JRightPadded<T> rp) {
+        Markers markers = rp.getMarkers();
+        markers = markers.withMarkers(ListUtils.map(markers.getMarkers(), marker ->
+                marker instanceof Semicolon ? null : marker
+        ));
+        return rp.withMarkers(markers);
+    }
+
+    private static class MyKotlinJavaPrinter extends KotlinPrinter.KotlinJavaPrinter<Set<J>> {
+        private final String sourceCode;
+
+        MyKotlinJavaPrinter(KotlinPrinter kp, String sourceCode) {
+            super(kp);
+            this.sourceCode = sourceCode;
+        }
+
+        @Override
+        public @NotNull J visitVariableDeclarations(J.@NotNull VariableDeclarations multiVariable,
+                                                    @NotNull PrintOutputCapture<Set<J>> p) {
+            J mv = super.visitVariableDeclarations(multiVariable, p);
+            if (startsWithNewLineAfterOffset(sourceCode, p.out.length())) {
+                for (J.VariableDeclarations.NamedVariable v : multiVariable.getVariables()) {
+                    p.getContext().add(v);
+                }
+            }
+            return mv;
+        }
+
+        @Override
+        public @NotNull J visitMethodInvocation(J.@NotNull MethodInvocation method, @NotNull PrintOutputCapture<Set<J>> p) {
+            J m = super.visitMethodInvocation(method, p);
+
+            if (startsWithNewLineAfterOffset(sourceCode, p.out.length())) {
+                p.getContext().add(m);
+            }
+
+            return m;
+        }
+
+        @Override
+        public @NotNull J visitBlock(J.@NotNull Block block, @NotNull PrintOutputCapture<Set<J>> p) {
+            J.Block b = (J.Block) super.visitBlock(block, p);
+
+            b = b.getPadding().withStatements(ListUtils.map(b.getPadding().getStatements(), rp -> {
+                if (rp.getElement() instanceof J.If) {
+                    p.getContext().add(rp.getElement());
+                } else if (rp.getElement() instanceof K.KReturn) {
+                    p.getContext().add(rp.getElement());
+                }
+
+                return rp;
+            }));
+            return b;
+        }
+
+        public static boolean startsWithNewLineAfterOffset(String str, int offset) {
+            if (offset >= str.length()) {
+                return false;
+            }
+
+            for (int i = offset; i < str.length(); i++) {
+                char c = str.charAt(i);
+                if (c != ' ' && c != '\t' && c != ';') {
+                    return c == '\n';
+                }
+            }
+            return false;
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = true)
+    private static class CollectSemicolonRemovableElements extends KotlinPrinter<Set<J>> {
+
+        public static void collect(String sourceCode, J j, Set<J> SemicolonRemovable) {
+            new CollectSemicolonRemovableElements(sourceCode).visit(j, new PrintOutputCapture<>(SemicolonRemovable));
+        }
+
+        CollectSemicolonRemovableElements(String sourceCode) {
+            super();
+            setDelegate(new MyKotlinJavaPrinter(this, sourceCode));
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolon.java
@@ -78,7 +78,7 @@ public class RemoveTrailingSemicolon extends Recipe {
 
         private class MyKotlinJavaPrinter extends KotlinPrinter.KotlinJavaPrinter<Set<Marker>> {
 
-            @org.openrewrite.internal.lang.Nullable
+            @Nullable
             private Integer mark;
             @Nullable
             private Marker semicolonMarker;

--- a/src/main/java/org/openrewrite/kotlin/cleanup/ReplaceCharToIntWithCode.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/ReplaceCharToIntWithCode.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.kotlin.KotlinParser;
@@ -31,7 +32,8 @@ import org.openrewrite.kotlin.tree.K;
 @EqualsAndHashCode(callSuper = true)
 public class ReplaceCharToIntWithCode extends Recipe {
     private static final MethodMatcher CHAR_TO_INT_METHOD_MATCHER = new MethodMatcher("kotlin.Char toInt()");
-    private static J.FieldAccess charCodeTemplate = null;
+    @Nullable
+    private static J.FieldAccess charCodeTemplate;
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/openrewrite/kotlin/cleanup/package-info.java
+++ b/src/main/java/org/openrewrite/kotlin/cleanup/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.kotlin.cleanup;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -1089,7 +1089,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         }
     }
 
-    public void trailingMarkers(Markers markers, PrintOutputCapture<P> p) {
+    private void trailingMarkers(Markers markers, PrintOutputCapture<P> p) {
         for (Marker marker : markers.getMarkers()) {
             if (marker instanceof CheckNotNull) {
                 KotlinPrinter.this.visitSpace(((CheckNotNull) marker).getPrefix(), KSpace.Location.CHECK_NOT_NULL_PREFIX, p);
@@ -1135,7 +1135,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
     @Override
     public <M extends Marker> M visitMarker(Marker marker, PrintOutputCapture<P> p) {
-        return (M) delegate.visitMarker(marker, p);
+        return delegate.visitMarker(marker, p);
     }
 
     private static final UnaryOperator<String> JAVA_MARKER_WRAPPER =

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -39,13 +39,13 @@ import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
-    private KotlinJavaPrinter<P> delegate;
+    private final KotlinJavaPrinter<P> delegate;
     public KotlinPrinter() {
-        delegate = new KotlinJavaPrinter<>(this);
+        delegate = delegate();
     }
 
-    protected void setDelegate(KotlinJavaPrinter<P> kotlinJavaPrinter) {
-        delegate = kotlinJavaPrinter;
+    protected KotlinJavaPrinter<P> delegate() {
+        return new KotlinJavaPrinter<>(this);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -39,12 +39,12 @@ import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
-    private KotlinJavaPrinter delegate;
+    private KotlinJavaPrinter<P> delegate;
     public KotlinPrinter() {
-        delegate = new KotlinJavaPrinter(this);
+        delegate = new KotlinJavaPrinter<>(this);
     }
 
-    public void setDelegate(KotlinJavaPrinter kotlinJavaPrinter) {
+    protected void setDelegate(KotlinJavaPrinter<P> kotlinJavaPrinter) {
         delegate = kotlinJavaPrinter;
     }
 
@@ -313,9 +313,9 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     }
 
     public static class KotlinJavaPrinter<P> extends JavaPrinter<P> {
-        KotlinPrinter kotlinPrinter;
+        KotlinPrinter<P> kotlinPrinter;
 
-        public KotlinJavaPrinter(KotlinPrinter kp) {
+        public KotlinJavaPrinter(KotlinPrinter<P> kp) {
             kotlinPrinter = kp;
         }
 
@@ -979,9 +979,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                     p.append(")");
                 }
 
-                if (variable.getMarkers().findFirst(Semicolon.class).isPresent()) {
-                    p.append(";");
-                }
+                variable.getMarkers().findFirst(Semicolon.class).ifPresent(m -> visitMarker(m, p));
             }
 
             afterSyntax(multiVariable, p);

--- a/src/test/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolonTest.java
+++ b/src/test/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolonTest.java
+++ b/src/test/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolonTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+@SuppressWarnings("All")
+class RemoveTrailingSemicolonTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveTrailingSemicolon());
+    }
+
+    @DocumentExample
+    @Test
+    void variableDeclaration() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  var foo = 1;
+                  var bar: Int;
+                  var baz: String = "a";
+              }
+              """,
+            """
+              fun method() {
+                  var foo = 1
+                  var bar: Int
+                  var baz: String = "a"
+              }
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void doNotChangeVariableDeclarationsInSameLine() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method() {
+                  var foo = 1; var bar: Int
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodInvocation() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  fun method (t : Test): Test {
+                      method(this);
+                      method(t);
+                      method(method(t));
+                      return this
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun method (t : Test): Test {
+                      method(this)
+                      method(t)
+                      method(method(t))
+                      return this
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeIfMethodInvocationsAreInASameLine() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  fun method (t : Test): Test {
+                      method(this); method(t)
+                      return this
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void imports() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.util.List;
+              import java.util.Map;
+              """,
+            """
+              import java.util.List
+              import java.util.Map
+              """
+          )
+        );
+    }
+
+    @Test
+    void noSemicolonAfterReturn() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  fun method(): Int {
+                      return 1;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun method(): Int {
+                      return 1
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noSemicolonAfterReturn2() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  fun method(): Int {
+                      return if (true) 1 else 2;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  fun method(): Int {
+                      return if (true) 1 else 2
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ifStatement() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method () {
+                  if (true) {
+                  };
+              }
+              """,
+            """
+              fun method () {
+                  if (true) {
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolonTest.java
+++ b/src/test/java/org/openrewrite/kotlin/cleanup/RemoveTrailingSemicolonTest.java
@@ -96,6 +96,34 @@ class RemoveTrailingSemicolonTest implements RewriteTest {
     }
 
     @Test
+    void operators() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  fun method() {
+                      var i = 0;
+                      i++;
+                      --i;
+                      i++; ++i;
+                  };
+              }
+              """,
+            """
+              class Test {
+                  fun method() {
+                      var i = 0
+                      i++
+                      --i
+                      i++; ++i
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotChangeIfMethodInvocationsAreInASameLine() {
         rewriteRun(
           kotlin(
@@ -118,10 +146,14 @@ class RemoveTrailingSemicolonTest implements RewriteTest {
             """
               import java.util.List;
               import java.util.Map;
+              
+              class T
               """,
             """
               import java.util.List
               import java.util.Map
+
+              class T
               """
           )
         );


### PR DESCRIPTION
Add a recipe `RemoveTrailingSemicolon` to remove redundant trailing semicolons in Kotlin, and it looks like this is common mistake from Java developers.

Also, update `KotlinPrinter` to be extendable.