### PR TITLE
Kotlin allows trailing commas in method invocations and after enums

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/ArrayTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ArrayTest.java
@@ -91,4 +91,19 @@ class ArrayTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void trailingComma() {
+        rewriteRun(
+          kotlin(
+            """
+              val integerArray: Array<Int> = arrayOf(
+                  1,
+                  2,
+                  3,
+              )
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/EnumTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/EnumTest.java
@@ -71,4 +71,18 @@ class EnumTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void comma() {
+        rewriteRun(
+                kotlin(
+                        """
+                          enum class Scope {
+                              None,
+                              Compile,
+                          }
+                          """
+                )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
@@ -505,4 +505,17 @@ class MethodInvocationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void trailingComma() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( s : String ) { }
+              val x = method ( "foo", )
+              val y = method ( if ( true ) "foo" else "bar" /*c1*/ , /*c2*/ )
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
The OpenRewrite Kotlin parser saves these in `Space` elements which in Java typically only contain whitespace characters.

Fixes: #220, #216