### PR TITLE
Correct printing of `!in` expressions

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/MinimumViableSpacingVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/MinimumViableSpacingVisitor.java
@@ -203,7 +203,7 @@ public class MinimumViableSpacingVisitor<P> extends KotlinIsoVisitor<P> {
     @Override
     public K.Binary visitBinary(K.Binary binary, P p) {
         K.Binary kb = super.visitBinary(binary, p);
-        if (kb.getOperator() ==  K.Binary.Type.Contains) {
+        if (kb.getOperator() ==  K.Binary.Type.Contains || kb.getOperator() ==  K.Binary.Type.NotContains) {
             kb = kb.getPadding().withOperator(kb.getPadding().getOperator().withBefore(updateSpace(kb.getPadding().getOperator().getBefore(), true)));
             kb = kb.withRight(spaceBefore(kb.getRight(), true));
         }

--- a/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -764,6 +764,7 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
         K.Binary b = super.visitBinary(binary, p);
         K.Binary.Type operator = b.getOperator();
         switch (operator) {
+            case NotContains:
             case Contains:
                 break;
             case Get:

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -91,6 +91,9 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             case Contains:
                 keyword = "in";
                 break;
+            case NotContains:
+                keyword = "!in";
+                break;
             case IdentityEquals:
                 keyword = "===";
                 break;
@@ -906,6 +909,20 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             visitContainer(delimiter, typeParam.getPadding().getBounds(), JContainer.Location.TYPE_BOUNDS, "&", "", p);
             afterSyntax(typeParam, p);
             return typeParam;
+        }
+
+        @Override
+        public J visitUnary(J.Unary unary, PrintOutputCapture<P> p) {
+            if (unary.getOperator() == J.Unary.Type.Not && unary.getExpression() instanceof K.Binary && ((K.Binary) unary.getExpression()).getOperator() == K.Binary.Type.NotContains) {
+                // This is a special case for the `!in` operator.
+                // The `!` is a unary operator, but the `in` is a binary operator.
+                // The `!` is printed as part of the binary operator.
+                beforeSyntax(unary, Space.Location.UNARY_PREFIX, p);
+                visit(unary.getExpression(), p);
+                afterSyntax(unary, p);
+                return unary;
+            }
+            return super.visitUnary(unary, p);
         }
 
         @Override

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -388,6 +388,7 @@ public interface K extends J {
 
         public enum Type {
             Contains,
+            NotContains,
             Get,
             IdentityEquals,
             IdentityNotEquals,

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -1536,8 +1536,9 @@ class KotlinParserVisitor(
                 }
 
                 // The `in` keyword is a function call to `contains` applied to a primitive range. I.E., `IntRange`, `LongRange`.
-                opPrefix = sourceBefore("in")
-                kotlinBinaryType = Binary.Type.Contains
+                opPrefix = whitespace()
+                kotlinBinaryType = if (skip("!")) Binary.Type.NotContains else Binary.Type.Contains
+                skip("in")
                 val rhs: FirExpression =
                     if (functionCall.explicitReceiver != null) functionCall.explicitReceiver!! else functionCall.dispatchReceiver
                 right = convertToExpression(rhs, data)!!

--- a/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
@@ -296,6 +296,17 @@ class BinaryTest implements RewriteTest {
         );
     }
 
+    @Test
+    void notIn() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = "x" !in arrayOf("x")
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/149")
     @Test
     void explicitReceiver() {


### PR DESCRIPTION
A Kotlin binary expression using the `!in` operator is parsed as a `K.Binary` (with operator `Contains`) inside a `J.Unary` (with operator `Not`). The `KotlinPrinter` prints a leading `!` back out, so `a !in b` is printed as `!a !in b`.
