### PR TITLE
Support anonymous objects without supertype

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -825,7 +825,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
             beforeSyntax(newClass, Space.Location.NEW_CLASS_PREFIX, p);
 
-            if (kObject != null) {
+            if (kObject != null && newClass.getClazz() != null) {
                 p.append(":");
             }
 

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -492,13 +492,14 @@ class KotlinParserVisitor(
         var typeExpressionPrefix = Space.EMPTY
         var prefix = Space.EMPTY
         var clazz: TypeTree? = null
-        if (source.startsWith("object", cursor)) {
-            skip("object")
+        if (skip("object")) {
             markers = markers.addIfAbsent(KObject(randomId(), objectPrefix))
-
-            typeExpressionPrefix = sourceBefore(":")
             prefix = whitespace()
-            clazz = visitElement(anonymousObject.superTypeRefs[0], data) as TypeTree?
+            if (skip(":")) {
+                typeExpressionPrefix = prefix
+                prefix = whitespace()
+                clazz = visitElement(anonymousObject.superTypeRefs[0], data) as TypeTree?
+            }
         } else {
             cursor(saveCursor)
         }
@@ -2564,8 +2565,7 @@ class KotlinParserVisitor(
         saveCursor = cursor
         before = whitespace()
         if (simpleFunction.body is FirSingleExpressionBlock) {
-            if (source.startsWith("=", cursor)) {
-                skip("=")
+            if (skip("=")) {
                 val singleExpressionBlock = SingleExpressionBlock(randomId())
                 body = visitElement(simpleFunction.body!!, data) as J.Block?
                 body = body!!.withPrefix(before)
@@ -2630,12 +2630,8 @@ class KotlinParserVisitor(
             var e = arguments[i]
             val savedCursor = cursor
             val before = whitespace()
-            if (source.startsWith("$", cursor)) {
-                skip("$")
-                val inBraces = source.startsWith("{", cursor)
-                if (inBraces) {
-                    skip("{")
-                }
+            if (skip("$")) {
+                val inBraces = skip("{")
                 if (e is FirConstExpression<*>) {
                     // Skip generated whitespace expression so that it's added to the prefix of the reference.
                     i += 1

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -441,4 +441,15 @@ class VariableDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void anonymousObjectWithoutSupertype() {
+        rewriteRun(
+          kotlin(
+            """
+              val x: Any = object  {}   .    javaClass
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
As for example the expression `object {}` an anonymous object expression doesn't need to declare any supertype.
