### PR TITLE
Correct handling of parentheses around logic expressions

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/BinaryTest.java
@@ -265,6 +265,18 @@ class BinaryTest implements RewriteTest {
     }
 
     @Test
+    void doubleLogicParenthesized() {
+        rewriteRun(
+          kotlin(
+            """
+              val b : Boolean = true
+              val x = ((b || b) && (b || b))
+              """
+          )
+        );
+    }
+
+    @Test
     void rem() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
Remove parentheses logic from `visitBinaryLogicExpression()`. Parentheses are handled by `visitElement()` and `wrapInParens()`.
