### PR TITLE
Parser must not gobble up characters beyond end of string element

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -2626,7 +2626,7 @@ class KotlinParserVisitor(
             var e = arguments[i]
             val savedCursor = cursor
             val before = whitespace()
-            if (skip("$")) {
+            if (cursor < e.source!!.endOffset && skip("$")) {
                 val inBraces = skip("{")
                 if (e is FirConstExpression<*>) {
                     // Skip generated whitespace expression so that it's added to the prefix of the reference.

--- a/src/test/java/org/openrewrite/kotlin/tree/StringTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/StringTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+@SuppressWarnings({"KotlinConstantConditions", "ControlFlowWithEmptyBody"})
+class StringTest implements RewriteTest {
+
+    @Test
+    void interpolationWithLeadingWhitespace() {
+        rewriteRun(
+          kotlin(
+            """
+              val n_functions = ""
+              val s =
+                  ""\"
+                              ${n_functions}
+              ""\".trimIndent()
+              """
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
String interpolation is desugared to concatenated strings. The parser must make sure to not read any of the whitespace which may already belong to the next element, as it could otherwise process a `$` delimited expression, which belongs to a later element.
