### PR TITLE
Better support for auto-formatting extension methods

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/MinimumViableSpacingVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/MinimumViableSpacingVisitor.java
@@ -23,6 +23,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.marker.ImplicitReturn;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.marker.Extension;
 import org.openrewrite.kotlin.marker.Implicit;
 import org.openrewrite.kotlin.marker.PrimaryConstructor;
 import org.openrewrite.kotlin.tree.K;
@@ -218,7 +219,8 @@ public class MinimumViableSpacingVisitor<P> extends KotlinIsoVisitor<P> {
             first = false;
         }
 
-        if (!first) {
+        boolean hasReceiverType = method.getMarkers().findFirst(Extension.class).isPresent();
+        if (!first && !hasReceiverType) {
             m = m.withName(m.getName().withPrefix(updateSpace(m.getName().getPrefix(), true)));
         }
 

--- a/src/test/java/org/openrewrite/kotlin/format/AutoFormatVisitorTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/AutoFormatVisitorTest.java
@@ -195,6 +195,19 @@ class AutoFormatVisitorTest implements RewriteTest {
     }
 
     @Test
+    void extensionMethod() {
+        rewriteRun(
+          kotlin(
+            """
+              fun String.extension(): Any {
+                  return ""
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void composite2() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
No spaces are required in front of the method name or before the second parameter in the parameter list (the first is the implicit receiver of the receiver type).

The following function
```kt
fun String.extension(): Any {
  return ""
}
```
should thus not be formatted as (notice three extra spaces)
```kt
fun  String. extension( ): Any {
  return ""
}
```