### PR TITLE
Support references to imported members

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -1113,13 +1113,15 @@ class KotlinParserVisitor(
                 }
                 if (receiver != null) {
                     val selectExpr =
-                        convertToExpression<Expression>(receiver, data)!!
-                    val after = whitespace()
-                    if (skip("?")) {
-                        markers = markers.addIfAbsent(IsNullSafe(randomId(), Space.EMPTY))
+                        convertToExpression<Expression>(receiver, data)
+                    if (selectExpr != null) {
+                        val after = whitespace()
+                        if (skip("?")) {
+                            markers = markers.addIfAbsent(IsNullSafe(randomId(), Space.EMPTY))
+                        }
+                        skip(".")
+                        select = JRightPadded.build(selectExpr).withAfter(after)
                     }
-                    skip(".")
-                    select = JRightPadded.build(selectExpr).withAfter(after)
                 }
             }
             val name = visitElement(namedReference, data) as J.Identifier
@@ -2335,7 +2337,7 @@ class KotlinParserVisitor(
         )
     }
 
-    override fun visitResolvedQualifier(resolvedQualifier: FirResolvedQualifier, data: ExecutionContext): J {
+    override fun visitResolvedQualifier(resolvedQualifier: FirResolvedQualifier, data: ExecutionContext): J? {
         val fieldAccess = resolvedQualifier.packageFqName.asString()
         val resolvedName =
             if (resolvedQualifier.relativeClassFqName == null) "" else "." + resolvedQualifier.relativeClassFqName!!.asString()
@@ -2355,6 +2357,8 @@ class KotlinParserVisitor(
                 }
             }
         }
+        if (name.isEmpty())
+            return null
         var typeTree: TypeTree = build(name.toString())
         if (resolvedQualifier.relativeClassFqName != null) {
             typeTree = typeTree.withType(typeMapping.type(resolvedQualifier))

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodInvocationTest.java
@@ -44,6 +44,30 @@ class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
+    void unqualifiedImportedCall() {
+        rewriteRun(
+          kotlin(
+            """
+              package pkg
+              
+              import pkg.Callee.calleeMethod
+              import pkg.Callee.CALLEE_FIELD
+              
+              class Caller {
+                  fun method(): Any = calleeMethod()
+                  fun method2(): Any = CALLEE_FIELD
+              }
+              
+              object Callee {
+                  const val CALLEE_FIELD = ""
+                  fun calleeMethod(): Unit = Unit
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void buildGradle() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
The imported members could be JVM statics or also on some Kotlin object.

Fixes: #251
