### PR TITLE
Update autoFormat to support trailing lambda well

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -778,7 +778,6 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             visitContainer("<", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", p);
             JContainer<Expression> argContainer = method.getPadding().getArguments();
 
-            visitSpace(argContainer.getBefore(), Space.Location.METHOD_INVOCATION_ARGUMENTS, p);
             List<JRightPadded<Expression>> args = argContainer.getPadding().getElements();
             boolean omitParensOnMethod = method.getMarkers().findFirst(OmitParentheses.class).isPresent();
 
@@ -786,6 +785,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             boolean isTrailingLambda = !args.isEmpty() && args.get(argCount - 1).getElement().getMarkers().findFirst(TrailingLambdaArgument.class).isPresent();
 
             if (!omitParensOnMethod) {
+                visitSpace(argContainer.getBefore(), Space.Location.METHOD_INVOCATION_ARGUMENTS, p);
                 p.append('(');
             }
 

--- a/src/test/java/org/openrewrite/kotlin/format/AutoFormatVisitorTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/AutoFormatVisitorTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.kotlin.format;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -237,6 +238,52 @@ class AutoFormatVisitorTest implements RewriteTest {
                       val GRANT_TYPE = "password"
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingLambda() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = "foo".let {
+                  it.length
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingLambdaWithParam() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = listOf(1).forEach { e -> println(e) }
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingLambdaWithParamTrailingComment() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = listOf(1).forEach { e, -> println(e) }
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingLambdaWithMethodRefParam() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = listOf(1).forEach(::println)
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/format/MinimumViableSpacingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/MinimumViableSpacingTest.java
@@ -345,4 +345,17 @@ class MinimumViableSpacingTest implements RewriteTest {
         );
     }
 
+    @Test
+    void trailingLambda() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = "foo".let {}
+              """,
+            """
+              val x="foo".let{}
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
@@ -40,6 +40,7 @@ import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
+import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -818,6 +819,23 @@ class SpacesTest implements RewriteTest {
                       for (i in 10 .. 42) {
                       }
                   }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void aroundOperatorsLambdaArrow() {
+            rewriteRun(
+              spaces(),
+              kotlin(
+                """
+                  val double: (Int)->Int = { it * 2 }
+                  val r: ()   ->   Unit = {}
+                  """,
+                """
+                  val double: (Int) -> Int = { it * 2 }
+                  val r: () -> Unit = {}
                   """
               )
             );

--- a/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
@@ -24,6 +24,21 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 @SuppressWarnings("RemoveRedundantQualifierName")
 class LambdaTest implements RewriteTest {
 
+
+    @Test
+    void trailingLambda() {
+        rewriteRun(
+          kotlin(
+            """
+              val x = "foo"   .     let {
+                  it.length
+              }
+              """
+          )
+        );
+    }
+
+
     @Test
     void binaryExpressionAsBody() {
         rewriteRun(


### PR DESCRIPTION
Talked with @knutwannheden about the approach  https://github.com/openrewrite/rewrite-kotlin/pull/253. 
we probably don't want to introduce a new `Infix` marker here.
This is an alternative solution to PR https://github.com/openrewrite/rewrite-kotlin/pull/253 without introducing a new `Infix` marker.


Currently, there is one test failing (see below), I think it should be covered by parsing improvement, moving the space after the comma in `e, -> println(e)`  from marker `TrailingComma.suffix` to the lambda arrow.
```java
    @Test
    void trailingLambdaWithParamTrailingComment() {
        rewriteRun(
          kotlin(
            """
              val x = listOf(1).forEach { e, -> println(e) }
              """
          )
        );
    }
```