### PR TITLE
Fix `UseStaticImport` use case

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -730,7 +730,19 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession) : Java
                     parameterTypes.add(javaType)
                 }
             }
+        } else if (simpleFunction != null && simpleFunction.valueParameters.isNotEmpty()) {
+            parameterTypes = ArrayList(simpleFunction.valueParameters.size)
+            for (parameter in simpleFunction.valueParameters) {
+                val parameterSymbol = parameter.symbol
+                val javaType: JavaType = if (parameterSymbol.fir is FirJavaValueParameter) {
+                    type(parameterSymbol.fir.returnTypeRef)
+                } else {
+                    type(parameterSymbol.resolvedReturnTypeRef)
+                }
+                parameterTypes.add(javaType)
+            }
         }
+
         var resolvedDeclaringType: JavaType.FullyQualified? = null
         if (functionCall.calleeReference is FirResolvedNamedReference) {
             if ((functionCall.calleeReference as FirResolvedNamedReference).resolvedSymbol is FirNamedFunctionSymbol) {

--- a/src/test/java/org/openrewrite/kotlin/UseStaticImportTest.java
+++ b/src/test/java/org/openrewrite/kotlin/UseStaticImportTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.UseStaticImport;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+public class UseStaticImportTest implements RewriteTest {
+
+    @Test
+    void noPriorImports() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("java.lang.Integer valueOf(..)")),
+          kotlin(
+            """
+              val i = Integer.valueOf(1)
+              """,
+            """
+              import java.lang.Integer.valueOf
+
+              val i = valueOf(1)
+              """
+          )
+        );
+    }
+
+    @Test
+    void withImports() {
+        rewriteRun(
+          spec -> spec.recipe(new UseStaticImport("java.lang.Integer valueOf(kotlin.Int)")),
+          kotlin(
+            """
+              import java.util.Collections
+
+              val i = Integer.valueOf(1)
+              """,
+            """
+              import java.lang.Integer.valueOf
+              import java.util.Collections
+
+              val i = valueOf(1)
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
The Java `UseStaticImport` recipe can now also be applied to Kotlin sources. To achieve this the following changes were necessary:

- Fix the type attribution for `J.MethodInvocation` so that it includes the parameter types, so that they can be matched by the `MethodMatcher` used by the recipe
- Modify `AddImport` so that it adds a prefix to the first statement in case it didn't already have any imports before

Note that for Kotlin the `MethodMatcher` currently doesn't match methods when it uses Java primitive types. Instead, the corresponding Kotlin wrapper type (like `kotlin.Int`) must be used.
