### PR TITLE
Support calls with member references without receiver as argument

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -614,7 +614,7 @@ class KotlinParserVisitor(
         }
 
         var typeArgs: JContainer<Expression>? = null
-        if (callableReferenceAccess.typeArguments.isNotEmpty()) {
+        if (getReceiver(callableReferenceAccess) != null && callableReferenceAccess.typeArguments.isNotEmpty()) {
             typeArgs = mapTypeArguments(callableReferenceAccess.typeArguments, data)
         }
 
@@ -1107,10 +1107,7 @@ class KotlinParserVisitor(
                 markers = markers.addIfAbsent(Extension(randomId()))
             }
             if (functionCall !is FirImplicitInvokeCall) {
-                var receiver = getReceiver(functionCall.explicitReceiver)
-                if (receiver == null) {
-                    receiver = getReceiver(functionCall.dispatchReceiver)
-                }
+                val receiver = getReceiver(functionCall)
                 if (receiver != null) {
                     val selectExpr =
                         convertToExpression<Expression>(receiver, data)
@@ -1176,6 +1173,18 @@ class KotlinParserVisitor(
                 type
             )
         }
+    }
+
+    private fun getReceiver(expression: FirQualifiedAccessExpression?): FirElement? {
+        if (expression?.source == null) {
+            return null
+        }
+
+        var receiver: FirElement? = getReceiver(expression.explicitReceiver)
+        if (receiver == null) {
+            receiver = getReceiver(expression.dispatchReceiver)
+        }
+        return receiver
     }
 
     private fun getReceiver(firElement: FirElement?): FirElement? {

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodReferenceTest.java
@@ -24,6 +24,23 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 class MethodReferenceTest implements RewriteTest {
 
     @Test
+    void anonymousClassArgument() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.util.function.Supplier
+
+              val s1: Supplier<List<String>> = Supplier(::emptyList)
+              val s2: Supplier<List<String>> = Supplier { emptyList() }
+
+              val s3 = Supplier<List<String>>(::emptyList)
+              val s4 = Supplier<List<String>> { emptyList() }
+              """
+          )
+        );
+    }
+
+    @Test
     void fieldReference() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
Support expressions like `Supplier(::emptyList)`.
