### PR TITLE
Support annotations on expressions

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -96,6 +96,20 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         return after;
     }
 
+    public J visitAnnotatedExpression(K.AnnotatedExpression annotatedExpression, P p) {
+        K.AnnotatedExpression ae = annotatedExpression;
+        ae = ae.withPrefix(visitSpace(ae.getPrefix(), KSpace.Location.ANNOTATED_EXPRESSION_PREFIX, p));
+        ae = ae.withMarkers(visitMarkers(ae.getMarkers(), p));
+        ae = ae.withAnnotations(ListUtils.map(ae.getAnnotations(), a -> visitAndCast(a, p)));
+        Expression temp = (Expression) visitExpression(ae, p);
+        if (!(temp instanceof K.AnnotatedExpression)) {
+            return temp;
+        } else {
+            ae = (K.AnnotatedExpression) temp;
+        }
+        return ae;
+    }
+
     public J visitBinary(K.Binary binary, P p) {
         K.Binary b = binary;
         b = b.withPrefix(visitSpace(b.getPrefix(), KSpace.Location.BINARY_PREFIX, p));
@@ -155,7 +169,12 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         } else {
             r = (K.KReturn) temp;
         }
-        r = r.withAnnotations(ListUtils.map(r.getAnnotations(), a -> visitAndCast(a, p)));
+        Expression temp2 = (Expression) visitExpression(r, p);
+        if (!(temp2 instanceof K.KReturn)) {
+            return temp2;
+        } else {
+            r = (K.KReturn) temp2;
+        }
         r = r.withExpression(visitAndCast(r.getExpression(), p));
         r = r.withLabel(visitAndCast(r.getLabel(), p));
         return r;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -84,6 +84,15 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     }
 
     @Override
+    public J visitAnnotatedExpression(K.AnnotatedExpression annotatedExpression, PrintOutputCapture<P> p) {
+        beforeSyntax(annotatedExpression, KSpace.Location.ANNOTATED_EXPRESSION_PREFIX, p);
+        visit(annotatedExpression.getAnnotations(), p);
+        visit(annotatedExpression.getExpression(), p);
+        afterSyntax(annotatedExpression, p);
+        return annotatedExpression;
+    }
+
+    @Override
     public J visitBinary(K.Binary binary, PrintOutputCapture<P> p) {
         beforeSyntax(binary, Space.Location.BINARY_PREFIX, p);
         String keyword = "";
@@ -173,7 +182,6 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
     @Override
     public J visitKReturn(K.KReturn kReturn, PrintOutputCapture<P> p) {
-        visit(kReturn.getAnnotations(), p);
         J.Return return_ = kReturn.getExpression();
         if (kReturn.getLabel() != null) {
             beforeSyntax(return_, Space.Location.RETURN_PREFIX, p);

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -320,6 +320,66 @@ public interface K extends J {
         }
     }
 
+    /**
+     * In Kotlin all expressions can be annotated with annotations with the corresponding annotation target.
+     */
+    @Getter
+    @SuppressWarnings("unchecked")
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    final class AnnotatedExpression implements K, Expression {
+
+        @With
+        UUID id;
+
+        @With
+        Space prefix;
+
+        @With
+        Markers markers;
+
+        @With
+        List<J.Annotation> annotations;
+
+        @With
+        Expression expression;
+
+        public AnnotatedExpression(UUID id, Space prefix, Markers markers, List<J.Annotation> annotations, Expression expression) {
+            this.id = id;
+            this.prefix = prefix;
+            this.markers = markers;
+            this.annotations = annotations;
+            this.expression = expression;
+        }
+
+        @Override
+        public <P> J acceptKotlin(KotlinVisitor<P> v, P p) {
+            return v.visitAnnotatedExpression(this, p);
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            return expression.getType();
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            // type must be changed on expression
+            return (T) this;
+        }
+
+        @Transient
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        @Override
+        public String toString() {
+            return withPrefix(Space.EMPTY).printTrimmed(new KotlinPrinter<>());
+        }
+    }
+
     @SuppressWarnings("unused")
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
@@ -669,14 +729,11 @@ public interface K extends J {
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @Data
-    final class KReturn implements K, Statement {
+    final class KReturn implements K, Statement, Expression {
 
         @With
         @EqualsAndHashCode.Include
         UUID id;
-
-        @With
-        List<J.Annotation> annotations;
 
         @With
         J.Return expression;
@@ -685,9 +742,8 @@ public interface K extends J {
         @Nullable
         J.Identifier label;
 
-        public KReturn(UUID id, List<Annotation> annotations, Return expression, @Nullable J.Identifier label) {
+        public KReturn(UUID id, Return expression, @Nullable J.Identifier label) {
             this.id = id;
-            this.annotations = annotations;
             this.expression = expression;
             this.label = label;
         }
@@ -715,6 +771,18 @@ public interface K extends J {
         }
 
         @Override
+        public @Nullable JavaType getType() {
+            //noinspection DataFlowIssue
+            return expression.getExpression().getType();
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            // to change the expression of a return, change the type of its expression
+            return (T) this;
+        }
+
+        @Override
         public <P> J acceptKotlin(KotlinVisitor<P> v, P p) {
             return v.visitKReturn(this, p);
         }
@@ -735,7 +803,7 @@ public interface K extends J {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @Data
     @With
-    final class KString implements K, Statement, Expression {
+    final class KString implements K, Expression {
         UUID id;
         Space prefix;
         Markers markers;
@@ -761,8 +829,8 @@ public interface K extends J {
 
         @Transient
         @Override
-        public CoordinateBuilder.Statement getCoordinates() {
-            return new CoordinateBuilder.Statement(this);
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
         }
 
         @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)

--- a/src/main/java/org/openrewrite/kotlin/tree/KSpace.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/KSpace.java
@@ -18,6 +18,7 @@ package org.openrewrite.kotlin.tree;
 public class KSpace {
     public enum Location {
         ANNOTATION_CALL_SITE_PREFIX,
+        ANNOTATED_EXPRESSION_PREFIX,
         BINARY_PREFIX,
         BINARY_OPERATOR,
         BINARY_SUFFIX,

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -2161,12 +2161,7 @@ class KotlinParserVisitor(
                 type
             )
         } else {
-            val annotations = mapAnnotations(propertyAccessExpression.annotations)
-            var j = visitElement(propertyAccessExpression.calleeReference, data)!!
-            if (j is J.Identifier && annotations != null) {
-                j = j.withAnnotations(annotations)
-            }
-            j
+            visitElement(propertyAccessExpression.calleeReference, data)!!
         }
     }
 
@@ -2307,15 +2302,6 @@ class KotlinParserVisitor(
     }
 
     override fun visitReturnExpression(returnExpression: FirReturnExpression, data: ExecutionContext): J {
-        val annotations: List<J.Annotation?>
-        if (returnExpression.annotations.isEmpty()) {
-            annotations = emptyList<J.Annotation>()
-        } else {
-            annotations = ArrayList(returnExpression.annotations.size)
-            for (annotation in returnExpression.annotations) {
-                annotations.add(visitElement(annotation, data) as J.Annotation?)
-            }
-        }
         var label: J.Identifier? = null
         val node = getRealPsiElement(returnExpression) as KtReturnExpression?
         val explicitReturn = node != null
@@ -2331,9 +2317,9 @@ class KotlinParserVisitor(
         if (returnExpression.result !is FirUnitExpression) {
             returnExpr = convertToExpression(returnExpression.result, data)
         }
-        val k =
-            K.KReturn(randomId(), annotations, J.Return(randomId(), prefix, Markers.EMPTY, returnExpr), label)
-        return if (explicitReturn) k else k.withMarkers(k.markers.addIfAbsent(ImplicitReturn(randomId())))
+
+        val markers = if (explicitReturn) Markers.EMPTY else Markers.EMPTY.addIfAbsent(ImplicitReturn(randomId()))
+        return K.KReturn(randomId(), J.Return(randomId(), prefix, markers, returnExpr), label)
     }
 
     override fun visitResolvedTypeRef(resolvedTypeRef: FirResolvedTypeRef, data: ExecutionContext): J {
@@ -4423,6 +4409,24 @@ class KotlinParserVisitor(
             }
         }
 
+        if (firElement is FirExpression && firElement.annotations.isNotEmpty()) {
+            val annotationsPrefix = whitespace()
+            val annotations = ArrayList<J.Annotation>(firElement.annotations.size)
+            for (annotation in firElement.annotations) {
+                annotations.add(visitElement(annotation, data) as J.Annotation)
+            }
+            return K.AnnotatedExpression(
+                randomId(),
+                annotationsPrefix,
+                Markers.EMPTY,
+                annotations,
+                visitElement0(firElement, data) as Expression
+            )
+        }
+        return visitElement0(firElement, data)
+    }
+
+    private fun visitElement0(firElement: FirElement, data: ExecutionContext): J? {
         return when (firElement) {
             // FIR error elements
             is FirErrorNamedReference -> visitErrorNamedReference(firElement, data)

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -350,7 +350,7 @@ class AnnotationTest implements RewriteTest {
                       }
               
                   @Ann inline fun < @Ann reified T > m ( @Ann s : @Ann String ) : String {
-                      @Ann return s
+                      @Ann return @Ann s
                   }
               }
               @Ann typealias Other = @Ann String
@@ -376,7 +376,6 @@ class AnnotationTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/267")
-    @ExpectedToFail
     void expressionAnnotationInsideLambda() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
There is a new `K.AnnotatedExpression` LST type which holds annotations of annotated expressions and is used to wrap expressions, whenever they are annotated in the source code.

This also required removing `K.KReturn#anntations` and because a return in Kotlin is actually an expression, `KReturn` now also implements `Expression`.

Similarly, a `K.KString` is not a statement, just an expression.

Fixes: #267
