### PR TITLE
Improve constructor delegation

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
@@ -23,6 +23,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.marker.ImplicitReturn;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.marker.Implicit;
 import org.openrewrite.kotlin.style.TabsAndIndentsStyle;
 import org.openrewrite.kotlin.tree.K;
 
@@ -652,7 +653,9 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
     @Nullable
     @Override
     public J visit(@Nullable Tree tree, P p) {
-        if (getCursor().getNearestMessage("stop") != null) {
+        if (tree instanceof J && tree.getMarkers().findFirst(Implicit.class).isPresent()) {
+            return (J) tree;
+        } else if (getCursor().getNearestMessage("stop") != null) {
             return (J) tree;
         }
         return super.visit(tree, p);


### PR DESCRIPTION
More consistently apply the `ConstructorDelegation` marker and a corresponding LST (`J.MethodInvocation` instead of `J.NewClass` inside `K.FunctionType`) when parsing the Kotlin constructor delegation construct.

Add some LST construction tests for this.

Issue: #270
