### PR TITLE
Allow `K.When#selector` to be a `J.VariableDeclarations` instance

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1307,7 +1307,7 @@ public interface K extends J {
 
         @Nullable
         @With
-        ControlParentheses<Expression> selector;
+        ControlParentheses<J> selector;
 
         @With
         Block branches;
@@ -1315,7 +1315,7 @@ public interface K extends J {
         @Nullable
         JavaType type;
 
-        public When(UUID id, Space prefix, Markers markers, @Nullable ControlParentheses<Expression> selector, Block branches, @Nullable JavaType type) {
+        public When(UUID id, Space prefix, Markers markers, @Nullable ControlParentheses<J> selector, Block branches, @Nullable JavaType type) {
             this.id = id;
             this.prefix = prefix;
             this.markers = markers;

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -3309,13 +3309,13 @@ class KotlinParserVisitor(
         val prefix = whitespace()
         if (skip("when")) {
             // Create the entire when expression here to simplify visiting `WhenBranch`, since `if` and `when` share the same data structure.
-            var controlParentheses: J.ControlParentheses<Expression>? = null
+            var controlParentheses: J.ControlParentheses<J>? = null
             if (whenExpression.subjectVariable != null) {
                 controlParentheses = J.ControlParentheses(
                     randomId(),
                     sourceBefore("("),
                     Markers.EMPTY,
-                    padRight(convertToExpression(whenExpression.subjectVariable!!, data)!!, sourceBefore(")"))
+                    padRight(visitElement(whenExpression.subjectVariable!!, data)!!, sourceBefore(")"))
                 )
             } else if (whenExpression.subject != null) {
                 controlParentheses = J.ControlParentheses(

--- a/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/WhenTest.java
@@ -264,7 +264,16 @@ class WhenTest implements RewriteTest {
                   is List -> "l"
                   else -> ""
               }
-              """
+              """,
+              spec -> spec.afterRecipe(cu -> {
+                  assertThat(cu.getStatements()).satisfiesExactly(
+                      stmt -> {
+                          J.VariableDeclarations x = (J.VariableDeclarations) stmt;
+                          K.When initializer = (K.When) x.getVariables().get(0).getInitializer();
+                          assertThat(initializer.getSelector().getTree()).isInstanceOf(J.VariableDeclarations.class);
+                      }
+                  );
+              })
           )
         );
     }


### PR DESCRIPTION
This is for the case when the `when` expression declares a subject variable.

Fixes: #240
