### PR TITLE
Map indexed access `get` operator to method invocation

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -831,18 +831,22 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
         @Override
         public J visitMethodInvocation(J.MethodInvocation method, PrintOutputCapture<P> p) {
+            boolean indexedAccess = method.getMarkers().findFirst(IndexedAccess.class).isPresent();
+
             beforeSyntax(method, Space.Location.METHOD_INVOCATION_PREFIX, p);
 
             visitRightPadded(method.getPadding().getSelect(), JRightPadded.Location.METHOD_SELECT, p);
-            if (method.getSelect() != null && !method.getMarkers().findFirst(Extension.class).isPresent()) {
+            if (method.getSelect() != null && !method.getMarkers().findFirst(Extension.class).isPresent() && !indexedAccess) {
                 if (method.getMarkers().findFirst(IsNullSafe.class).isPresent()) {
                     p.append("?");
                 }
                 p.append(".");
             }
 
-            visit(method.getName(), p);
-            visitContainer("<", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", p);
+            if (!indexedAccess) {
+                visit(method.getName(), p);
+                visitContainer("<", method.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ">", p);
+            }
 
             visitArgumentsContainer(method.getPadding().getArguments(), Space.Location.METHOD_INVOCATION_ARGUMENTS, p);
 
@@ -854,12 +858,13 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             visitSpace(argContainer.getBefore(), argsLocation, p);
             List<JRightPadded<Expression>> args = argContainer.getPadding().getElements();
             boolean omitParensOnMethod = argContainer.getMarkers().findFirst(OmitParentheses.class).isPresent();
+            boolean indexedAccess = argContainer.getMarkers().findFirst(IndexedAccess.class).isPresent();
 
             int argCount = args.size();
             boolean isTrailingLambda = !args.isEmpty() && args.get(argCount - 1).getElement().getMarkers().findFirst(TrailingLambdaArgument.class).isPresent();
 
             if (!omitParensOnMethod) {
-                p.append('(');
+                p.append(indexedAccess ? '[' : '(');
             }
 
             for (int i = 0; i < argCount; i++) {
@@ -869,7 +874,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                 if (i == argCount - 1 && isTrailingLambda) {
                     visitSpace(arg.getAfter(), JRightPadded.Location.METHOD_INVOCATION_ARGUMENT.getAfterLocation(), p);
                     if (!omitParensOnMethod) {
-                        p.append(")");
+                        p.append(indexedAccess ? ']' : ')');
                     }
                     visit(arg.getElement(), p);
                     break;
@@ -878,7 +883,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                 if (i > 0 && omitParensOnMethod && (
                         !args.get(0).getElement().getMarkers().findFirst(OmitParentheses.class).isPresent() &&
                         !args.get(0).getElement().getMarkers().findFirst(OmitParentheses.class).isPresent())) {
-                    p.append(')');
+                    p.append(indexedAccess ? ']' : ')');
                 } else if (i > 0) {
                     p.append(',');
                 }
@@ -886,13 +891,13 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                 SpreadArgument spread = arg.getElement().getMarkers().findFirst(SpreadArgument.class).orElse(null);
                 if (spread != null) {
                     kotlinPrinter.visitSpace(spread.getPrefix(), KSpace.Location.SPREAD_ARGUMENT_PREFIX, p);
-                    p.append("*");
+                    p.append('*');
                 }
                 visitRightPadded(arg, JRightPadded.Location.METHOD_INVOCATION_ARGUMENT, p);
             }
 
             if (!omitParensOnMethod && !isTrailingLambda) {
-                p.append(')');
+                p.append(indexedAccess ? ']' : ')');
             }
         }
 

--- a/src/main/java/org/openrewrite/kotlin/marker/IndexedAccess.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/IndexedAccess.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+@Value
+@With
+public class IndexedAccess implements Marker {
+    UUID id;
+
+    public IndexedAccess(UUID id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
While the Kotlin index access `get` operator is an operator, its syntax is more like a regular method invocation, with the difference that the method name (`get`) is implicit and that the arguments appear inside square brackets rather than regular parentheses. Also, under the hood, this will of course get mapped to a method invocation (which is also mostly true for Kotlin's other operators).

This commit changes the parsing to map the `get` operator to a `J.MethodInvocation` rather than a `K.Binary` and adds an `IndexedAccess` marker to it, so that it can get printed correctly again.

Fixes: #233
