### PR TITLE
Fix type attribution for extension methods

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -722,14 +722,18 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession) : Java
             simpleFunction = symbol.fir as FirSimpleFunction
         }
         var paramNames: MutableList<String>? = null
+        if (simpleFunction?.receiverParameter != null) {
+            paramNames = ArrayList(simpleFunction.valueParameters.size + 1)
+            paramNames.add("receiver")
+        }
         if (simpleFunction != null && simpleFunction.valueParameters.isNotEmpty()) {
-            paramNames = ArrayList(simpleFunction.valueParameters.size)
+            paramNames = paramNames ?: ArrayList(simpleFunction.valueParameters.size)
             for (p: FirValueParameter in simpleFunction.valueParameters) {
                 val s = p.name.asString()
                 paramNames.add(s)
             }
         } else if (constructor != null && constructor.valueParameters.isNotEmpty()) {
-            paramNames = ArrayList(constructor.valueParameters.size)
+            paramNames = paramNames ?: ArrayList(constructor.valueParameters.size)
             for (p: FirValueParameter in constructor.valueParameters) {
                 val s = p.name.asString()
                 paramNames.add(s)
@@ -746,6 +750,10 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession) : Java
         )
         typeCache.put(signature, method)
         var parameterTypes: MutableList<JavaType>? = null
+        if (simpleFunction?.receiverParameter != null) {
+            parameterTypes = ArrayList(simpleFunction.valueParameters.size + 1)
+            parameterTypes.add(type(simpleFunction.receiverParameter!!.typeRef))
+        }
         if (constructor != null && constructor.valueParameters.isNotEmpty()) {
             parameterTypes = ArrayList(constructor.valueParameters.size)
             for (argtype: FirValueParameter? in constructor.valueParameters) {
@@ -755,7 +763,7 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession) : Java
                 }
             }
         } else if (simpleFunction != null && simpleFunction.valueParameters.isNotEmpty()) {
-            parameterTypes = ArrayList(simpleFunction.valueParameters.size)
+            parameterTypes = parameterTypes ?: ArrayList(simpleFunction.valueParameters.size)
             for (parameter in simpleFunction.valueParameters) {
                 val parameterSymbol = parameter.symbol
                 val javaType: JavaType = if (parameterSymbol.fir is FirJavaValueParameter) {

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -724,7 +724,7 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession) : Java
         var paramNames: MutableList<String>? = null
         if (simpleFunction?.receiverParameter != null) {
             paramNames = ArrayList(simpleFunction.valueParameters.size + 1)
-            paramNames.add("receiver")
+            paramNames.add('$'+ "this" + '$')
         }
         if (simpleFunction != null && simpleFunction.valueParameters.isNotEmpty()) {
             paramNames = paramNames ?: ArrayList(simpleFunction.valueParameters.size)

--- a/src/test/java/org/openrewrite/kotlin/FindMethodsTest.java
+++ b/src/test/java/org/openrewrite/kotlin/FindMethodsTest.java
@@ -53,4 +53,23 @@ public class FindMethodsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void extensionMethod() {
+        rewriteRun(
+          spec -> spec.recipe(new FindMethods("kotlin.collections.CollectionsKt last(kotlin.collections.List)", false)),
+          kotlin(
+            """
+              val l = listOf("one")
+              val r1 = l.last()
+              val r2 = (l as Iterable<String>).last()
+              """,
+            """
+              val l = listOf("one")
+              val r1 = /*~~>*/l.last()
+              val r2 = (l as Iterable<String>).last()
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Extension method calls should be type attributed with a `JavaType.Method` where the receiver type of the extension method is the first parameter.
