### PR TITLE
Ready to support kotlin script parsing, parser to be implemented

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/Assertions.java
+++ b/src/main/java/org/openrewrite/kotlin/Assertions.java
@@ -48,6 +48,11 @@ public final class Assertions {
         });
     }
 
+    public static SourceSpecs kotlinScript(@Language("kts") @Nullable String before) {
+        return kotlinScript(before, s -> {
+        });
+    }
+
     public static SourceSpecs kotlin(@Language("kotlin") @Nullable String before, Consumer<SourceSpec<K.CompilationUnit>> spec) {
         SourceSpec<K.CompilationUnit> kotlin = new SourceSpec<>(
                 K.CompilationUnit.class, null, KotlinParser.builder(), before,
@@ -56,6 +61,16 @@ public final class Assertions {
         );
         acceptSpec(spec, kotlin);
         return kotlin;
+    }
+
+    public static SourceSpecs kotlinScript(@Language("kts") @Nullable String before, Consumer<SourceSpec<K.CompilationUnit>> spec) {
+        SourceSpec<K.CompilationUnit> kotlinScript = new SourceSpec<>(
+                K.CompilationUnit.class, null, KotlinParser.builder().isKotlinScript(true), before,
+                SourceSpec.EachResult.noop,
+                Assertions::customizeExecutionContext
+        );
+        acceptSpec(spec, kotlinScript);
+        return kotlinScript;
     }
 
     public static SourceSpecs kotlin(@Language("kotlin") @Nullable String before, @Language("kotlin") String after) {

--- a/src/test/java/org/openrewrite/kotlin/tree/KTSTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/KTSTest.java
@@ -21,7 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlinScript;
 
-public class KTSTest implements RewriteTest {
+class KTSTest implements RewriteTest {
 
     @ExpectedToFail("KTS parser is not implemented yet")
     @Test

--- a/src/test/java/org/openrewrite/kotlin/tree/KTSTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/KTSTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.tree;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlinScript;
+
+public class KTSTest implements RewriteTest {
+
+    @ExpectedToFail("KTS parser is not implemented yet")
+    @Test
+    void helloWorld() {
+        rewriteRun(
+          kotlinScript("""
+            println("Hello, World!")
+            """)
+        );
+    }
+
+}


### PR DESCRIPTION
I found that there is no configuration change required, just change the file suffix to `.kts` and the Kotlin compiler supports it.
Given the Kitlin script code like this 
```kotlin
println("Hello, World!")
```

Print `ktFile` output from the Kotlin compiler

1. If parse it as a *.kt file, we can see a lot of `ERROR_ELEMENT` in both FIR and PSI.
```
------------
PSI Tree All
\---(0,24) | kotlin.FILE | KtFile | Text: "println("Hello, World!")"
    |---(0,0) | PACKAGE_DIRECTIVE | KtPackageDirective | Text: ""
    |---(0,0) | IMPORT_LIST | KtImportList | Text: ""
    |---(0,7) | ERROR_ELEMENT | PsiErrorElementImpl | Text: "println"
    |   \---(0,7) | IDENTIFIER | LeafPsiElement | Text: "println"
    |---(7,8) | ERROR_ELEMENT | PsiErrorElementImpl | Text: "("
    |   \---(7,8) | LPAR | LeafPsiElement | Text: "("
    |---(8,9) | ERROR_ELEMENT | PsiErrorElementImpl | Text: """
    |   \---(8,9) | OPEN_QUOTE | LeafPsiElement | Text: """
    |---(9,22) | ERROR_ELEMENT | PsiErrorElementImpl | Text: "Hello, World!"
    |   \---(9,22) | REGULAR_STRING_PART | LeafPsiElement | Text: "Hello, World!"
    |---(22,23) | ERROR_ELEMENT | PsiErrorElementImpl | Text: """
    |   \---(22,23) | CLOSING_QUOTE | LeafPsiElement | Text: """
    \---(23,24) | ERROR_ELEMENT | PsiErrorElementImpl | Text: ")"
        \---(23,24) | RPAR | LeafPsiElement | Text: ")"
```

2. If parse it as a *.kts file. both FIR and PSI looks good to me
```
------------
PSI Tree All
\---(0,24) | kotlin.FILE | KtFile | Text: "println("Hello, World!")"
    |---(0,0) | PACKAGE_DIRECTIVE | KtPackageDirective | Text: ""
    |---(0,0) | IMPORT_LIST | KtImportList | Text: ""
    \---(0,24) | SCRIPT | KtScript | Text: "println("Hello, World!")"
        \---(0,24) | BLOCK | KtBlockExpression | Text: "println("Hello, World!")"
            \---(0,24) | SCRIPT_INITIALIZER | KtScriptInitializer | Text: "println("Hello, World!")"
                \---(0,24) | CALL_EXPRESSION | KtCallExpression | Text: "println("Hello, World!")"
                    |---(0,7) | REFERENCE_EXPRESSION | KtNameReferenceExpression | Text: "println"
                    |   \---(0,7) | IDENTIFIER | LeafPsiElement | Text: "println"
                    \---(7,24) | VALUE_ARGUMENT_LIST | KtValueArgumentList | Text: "("Hello, World!")"
                        |---(7,8) | LPAR | LeafPsiElement | Text: "("
                        |---(8,23) | VALUE_ARGUMENT | KtValueArgument | Text: ""Hello, World!""
                        |   \---(8,23) | STRING_TEMPLATE | KtStringTemplateExpression | Text: ""Hello, World!""
                        |       |---(8,9) | OPEN_QUOTE | LeafPsiElement | Text: """
                        |       |---(9,22) | LITERAL_STRING_TEMPLATE_ENTRY | KtLiteralStringTemplateEntry | Text: "Hello, World!"
                        |       |   \---(9,22) | REGULAR_STRING_PART | LeafPsiElement | Text: "Hello, World!"
                        |       \---(22,23) | CLOSING_QUOTE | LeafPsiElement | Text: """
                        \---(23,24) | RPAR | LeafPsiElement | Text: ")"
```

