### PR TITLE
Fix anonymous object print idempotent issue

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -403,7 +403,7 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
             m = ins.withPrefix(visitSpace(ins.getPrefix(), KSpace.Location.IS_NULLABLE_PREFIX, p));
         } else if (marker instanceof KObject) {
             KObject ko = (KObject) marker;
-            m = ko.withSuffix(visitSpace(ko.getSuffix(), KSpace.Location.OBJECT_PREFIX, p));
+            m = ko.withPrefix(visitSpace(ko.getPrefix(), KSpace.Location.OBJECT_PREFIX, p));
         } else if (marker instanceof SpreadArgument) {
             SpreadArgument sa = (SpreadArgument) marker;
             m = sa.withPrefix(visitSpace(sa.getPrefix(), KSpace.Location.SPREAD_ARGUMENT_PREFIX, p));

--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -403,7 +403,7 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
             m = ins.withPrefix(visitSpace(ins.getPrefix(), KSpace.Location.IS_NULLABLE_PREFIX, p));
         } else if (marker instanceof KObject) {
             KObject ko = (KObject) marker;
-            m = ko.withPrefix(visitSpace(ko.getPrefix(), KSpace.Location.OBJECT_PREFIX, p));
+            m = ko.withSuffix(visitSpace(ko.getSuffix(), KSpace.Location.OBJECT_PREFIX, p));
         } else if (marker instanceof SpreadArgument) {
             SpreadArgument sa = (SpreadArgument) marker;
             m = sa.withPrefix(visitSpace(sa.getPrefix(), KSpace.Location.SPREAD_ARGUMENT_PREFIX, p));

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -941,13 +941,13 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
         @Override
         public J visitNewClass(J.NewClass newClass, PrintOutputCapture<P> p) {
+            beforeSyntax(newClass, Space.Location.NEW_CLASS_PREFIX, p);
+
             KObject kObject = newClass.getMarkers().findFirst(KObject.class).orElse(null);
             if (kObject != null) {
-                kotlinPrinter.visitSpace(kObject.getPrefix(), KSpace.Location.OBJECT_PREFIX, p);
                 p.append("object");
+                kotlinPrinter.visitSpace(kObject.getSuffix(), KSpace.Location.OBJECT_PREFIX, p);
             }
-
-            beforeSyntax(newClass, Space.Location.NEW_CLASS_PREFIX, p);
 
             if (kObject != null && newClass.getClazz() != null) {
                 p.append(":");

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -946,7 +946,12 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             KObject kObject = newClass.getMarkers().findFirst(KObject.class).orElse(null);
             if (kObject != null) {
                 p.append("object");
-                kotlinPrinter.visitSpace(kObject.getSuffix(), KSpace.Location.OBJECT_PREFIX, p);
+                kotlinPrinter.visitSpace(kObject.getPrefix(), KSpace.Location.OBJECT_PREFIX, p);
+            }
+
+            TypeReferencePrefix typeReferencePrefix = newClass.getMarkers().findFirst(TypeReferencePrefix.class).orElse(null);
+            if (typeReferencePrefix != null) {
+                kotlinPrinter.visitSpace(typeReferencePrefix.getPrefix(), KSpace.Location.TYPE_REFERENCE_PREFIX, p);
             }
 
             if (kObject != null && newClass.getClazz() != null) {

--- a/src/main/java/org/openrewrite/kotlin/marker/KObject.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/KObject.java
@@ -26,10 +26,10 @@ import java.util.UUID;
 @With
 public class KObject implements Marker {
     UUID id;
-    Space prefix;
+    Space suffix;
 
-    public KObject(UUID id, Space prefix) {
+    public KObject(UUID id, Space suffix) {
         this.id = id;
-        this.prefix = prefix;
+        this.suffix = suffix;
     }
 }

--- a/src/main/java/org/openrewrite/kotlin/marker/KObject.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/KObject.java
@@ -26,10 +26,11 @@ import java.util.UUID;
 @With
 public class KObject implements Marker {
     UUID id;
-    Space suffix;
+    @Deprecated
+    Space prefix;
 
-    public KObject(UUID id, Space suffix) {
+    public KObject(UUID id, Space prefix) {
         this.id = id;
-        this.suffix = suffix;
+        this.prefix = prefix;
     }
 }

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -556,22 +556,20 @@ class KotlinParserVisitor(
 
     override fun visitAnonymousObject(anonymousObject: FirAnonymousObject, data: ExecutionContext): J {
         var saveCursor = cursor
-        val objectPrefix = whitespace()
+
         var markers = Markers.EMPTY
         var typeExpressionPrefix = Space.EMPTY
-        var prefix = Space.EMPTY
+        val newClassPrefix = whitespace()
         var clazz: TypeTree? = null
         if (skip("object")) {
-            markers = markers.addIfAbsent(KObject(randomId(), objectPrefix))
-            prefix = whitespace()
+            val objectSuffix = whitespace()
+            markers = markers.addIfAbsent(KObject(randomId(), objectSuffix))
             if (skip(":")) {
-                typeExpressionPrefix = prefix
-                prefix = whitespace()
+                typeExpressionPrefix = whitespace()
                 clazz = visitElement(anonymousObject.superTypeRefs[0], data) as TypeTree?
             }
-        } else {
-            cursor(saveCursor)
         }
+
         val args: JContainer<Expression>
         saveCursor = cursor
         val before = whitespace()
@@ -632,7 +630,7 @@ class KotlinParserVisitor(
         }
         return J.NewClass(
             randomId(),
-            prefix,
+            newClassPrefix,
             markers,
             null,
             typeExpressionPrefix,

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -563,7 +563,8 @@ class KotlinParserVisitor(
         var clazz: TypeTree? = null
         if (skip("object")) {
             val objectSuffix = whitespace()
-            markers = markers.addIfAbsent(KObject(randomId(), objectSuffix))
+            markers = markers.addIfAbsent(KObject(randomId(), Space.EMPTY))
+            markers = markers.addIfAbsent(TypeReferencePrefix(randomId(), objectSuffix))
             if (skip(":")) {
                 typeExpressionPrefix = whitespace()
                 clazz = visitElement(anonymousObject.superTypeRefs[0], data) as TypeTree?

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -63,7 +63,7 @@ class VariableDeclarationTest implements RewriteTest {
           kotlin(
             """
               open class Test
-              val o: Test = object : Test ( ) { }
+              val o  : Test   =  object   :     Test  (   )     {    }
               """
           )
         );


### PR DESCRIPTION
This PR is intended to fix the issue https://github.com/openrewrite/rewrite-kotlin/issues/315

I think the issue is caused by unreasonable space arragement.
For instance, code
```java
open class Test
val o  : Test   =  object   :     Test  (   )     {    }
```

identify the space before and after `object`
```java
val o  : Test   = /*space1*/ object /*space2*/  :  /*space3*/   Test  (   )     {    }
```

Before:
`space1` is the prefix of `object` in a marker `KObject`.
`space2` is the prefix of `new`  (or TypeExpression)
`space3` is the prefix of the entire initializer (new class)

Proposed in this Fix:
`space1` is prefix of the entire initializer (new class)
`space2` is the prefix of `TypeReferencePrefix` marker.
`space3` is the prefix of `new`  (or TypeExpression)

