### PR TITLE
Fix extension property getter/setter parse-to-print idempotent issue

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -289,7 +289,9 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         } else {
             pr = (K.Property) temp;
         }
+
         pr = pr.withVariableDeclarations(visitAndCast(pr.getVariableDeclarations(), p));
+        pr = pr.getPadding().withReceiverName(visitRightPadded(pr.getPadding().getReceiverName(), p));
         pr = pr.withGetter(visitAndCast(pr.getGetter(), p));
         pr = pr.withSetter(visitAndCast(pr.getSetter(), p));
         return pr;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -333,6 +333,11 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
         Extension extension = vd.getMarkers().findFirst(Extension.class).orElse(null);
         if (extension != null) {
+            if (property.getReceiverName() != null) {
+                visitRightPadded(property.getPadding().getReceiverName(), p);
+                p.append(".");
+            }
+
             if (property.getSetter() != null &&
                 !property.getSetter().getParameters().isEmpty() &&
                 property.getSetter().getParameters().get(0) instanceof J.VariableDeclarations) {

--- a/src/main/java/org/openrewrite/kotlin/marker/Extension.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/Extension.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 public class Extension implements Marker {
     UUID id;
 
+
     public Extension(UUID id) {
         this.id = id;
     }

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1418,7 +1418,17 @@ public interface K extends J {
 
         boolean isSetterFirst;
 
-        public Property(UUID id, Space prefix, Markers markers, @Nullable JContainer<TypeParameter> typeParameters, VariableDeclarations variableDeclarations, @Nullable J.MethodDeclaration getter, @Nullable J.MethodDeclaration setter, boolean isSetterFirst) {
+        @Nullable
+        JRightPadded<J> receiverName;
+
+        @Nullable
+        public J getReceiverName() {
+            return receiverName == null ? null : receiverName.getElement();
+        }
+
+        public Property(UUID id, Space prefix, Markers markers, @Nullable JContainer<TypeParameter> typeParameters, VariableDeclarations variableDeclarations,
+                        @Nullable J.MethodDeclaration getter, @Nullable J.MethodDeclaration setter, boolean isSetterFirst,
+                        @Nullable JRightPadded<J> receiverName) {
             this.id = id;
             this.prefix = prefix;
             this.markers = markers;
@@ -1427,6 +1437,7 @@ public interface K extends J {
             this.getter = getter;
             this.setter = setter;
             this.isSetterFirst = isSetterFirst;
+            this.receiverName = receiverName;
         }
 
         @Override
@@ -1470,7 +1481,17 @@ public interface K extends J {
             }
 
             public Property withTypeParameters(@Nullable JContainer<TypeParameter> typeParameters) {
-                return t.typeParameters == typeParameters ? t : new Property(t.id, t.prefix, t.markers, typeParameters, t.variableDeclarations, t.getter, t.setter, t.isSetterFirst);
+                return t.typeParameters == typeParameters ? t : new Property(t.id, t.prefix, t.markers, typeParameters, t.variableDeclarations, t.getter, t.setter, t.isSetterFirst, t.receiverName);
+            }
+
+            @Nullable
+            public JRightPadded<J> getReceiverName() {
+                return t.receiverName;
+            }
+
+            @Nullable
+            public Property withReceiverName(@Nullable JRightPadded<J> receiverName) {
+                return t.receiverName == receiverName ? t : new Property(t.id, t.prefix, t.markers, t.typeParameters, t.variableDeclarations, t.getter, t.setter, t.isSetterFirst, receiverName);
             }
         }
     }

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -90,7 +90,7 @@ class VariableDeclarationTest implements RewriteTest {
           kotlin(
             """
               class Spec
-              inline val Spec . `java-base` : String get ( ) = "  "
+              inline val  Spec   .    `java-base`     : String  get   (    )   =  "  "
               """
           )
         );
@@ -99,7 +99,6 @@ class VariableDeclarationTest implements RewriteTest {
     @Test
     void getter() {
         rewriteRun(
-          kotlin("class Spec"),
           kotlin(
             """
               val isEmpty : Boolean


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-kotlin/issues/318

I found this is not an easy space-related fix, but need to change the model.
The root cause is that `getter`/`setter` is supposed to have a `J.Empty` as a parameter, however, it's overridden to store the receiver name, and accordingly, the stored space is erased.
To fix this problem, introduced a new field `receiverName` to `K.Property` to store the receiver name.
