### PR TITLE
Declare `K.FunctionType#arrow` as nullable

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -945,7 +945,9 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
         K.FunctionType kf = super.visitFunctionType(functionType, p);
 
         // handle space around arrow in function type
-        kf = kf.withArrow(updateSpace(kf.getArrow(), style.getOther().getAroundArrowInFunctionTypes()));
+        if (kf.getArrow() != null) {
+            kf = kf.withArrow(updateSpace(kf.getArrow(), style.getOther().getAroundArrowInFunctionTypes()));
+        }
         kf = kf.withReturnType(spaceBefore(kf.getReturnType(), style.getOther().getAroundArrowInFunctionTypes()));
         return kf;
     }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -226,7 +226,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             p.append(".");
         }
         delegate.visitContainer("(", functionType.getPadding().getParameters(), JContainer.Location.TYPE_PARAMETERS, ",", ")", p);
-        visitSpace(functionType.getArrow(), KSpace.Location.FUNCTION_TYPE_ARROW_PREFIX, p);
+        visitSpace(functionType.getArrow() != null ? functionType.getArrow() : Space.SINGLE_SPACE, KSpace.Location.FUNCTION_TYPE_ARROW_PREFIX, p);
         p.append("->");
         visit(functionType.getReturnType(), p);
         if (nullable) {

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1007,7 +1007,7 @@ public interface K extends J {
 
         public FunctionType(UUID id, Space prefix, Markers markers, List<Annotation> leadingAnnotations,
                             List<Modifier> modifiers, @Nullable JRightPadded<NameTree> receiver,
-                            JContainer<TypeTree> parameters, Space arrow, TypedTree returnType) {
+                            JContainer<TypeTree> parameters, @Nullable Space arrow, TypedTree returnType) {
             this.id = id;
             this.prefix = prefix;
             this.markers = markers;
@@ -1067,6 +1067,7 @@ public interface K extends J {
             return getPadding().withParameters(JContainer.withElementsNullable(this.parameters, parameters));
         }
 
+        @Nullable // nullable for LST backwards compatibility reasons only
         @With
         @Getter
         Space arrow;


### PR DESCRIPTION
For LST backwards compatibility reasons the field is for the time being declared as nullable.
