### PR TITLE
Add new Kotlin formatting options

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/AutoFormatVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/AutoFormatVisitor.java
@@ -70,9 +70,11 @@ public class AutoFormatVisitor<P> extends KotlinIsoVisitor<P> {
                 .orElse(IntelliJ.tabsAndIndents()), stopAfter)
                 .visit(t, p, cursor.fork());
 
-        t = new TabsAndIndentsVisitor<>(Optional.ofNullable(((SourceFile) cu).getStyle(TabsAndIndentsStyle.class))
-                .orElse(IntelliJ.tabsAndIndents()), stopAfter)
-                .visit(t, p, cursor.fork());
+        t = new TabsAndIndentsVisitor<>(
+                Optional.ofNullable(((SourceFile) cu).getStyle(TabsAndIndentsStyle.class)).orElse(IntelliJ.tabsAndIndents()),
+                Optional.ofNullable(((SourceFile) cu).getStyle(WrappingAndBracesStyle.class)).orElse(IntelliJ.wrappingAndBraces()),
+                stopAfter
+        ).visit(t, p, cursor.fork());
 
         t = new NormalizeLineBreaksVisitor<>(Optional.ofNullable(((SourceFile) cu).getStyle(GeneralFormatStyle.class))
                 .orElse(new GeneralFormatStyle(false)), stopAfter)
@@ -113,9 +115,11 @@ public class AutoFormatVisitor<P> extends KotlinIsoVisitor<P> {
                     .orElse(IntelliJ.tabsAndIndents()), stopAfter)
                     .visit(t, p);
 
-            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(Optional.ofNullable(((SourceFile) cu).getStyle(TabsAndIndentsStyle.class))
-                    .orElse(IntelliJ.tabsAndIndents()), stopAfter)
-                    .visit(t, p);
+            t = (JavaSourceFile) new TabsAndIndentsVisitor<>(
+                    Optional.ofNullable(((SourceFile) cu).getStyle(TabsAndIndentsStyle.class)).orElse(IntelliJ.tabsAndIndents()),
+                    Optional.ofNullable(((SourceFile) cu).getStyle(WrappingAndBracesStyle.class)).orElse(IntelliJ.wrappingAndBraces()),
+                    stopAfter
+            ).visit(t, p);
 
             assert t != null;
             return t;

--- a/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
@@ -435,9 +435,6 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
                 case IMPLEMENTS:
                     getCursor().putMessage("indentType", wrappingStyle.getExtendsImplementsPermitsList().getUseContinuationIndent() ? IndentType.CONTINUATION_INDENT : IndentType.INDENT);
                     break;
-//                case METHOD_DECLARATION_PARAMETERS:
-//                    getCursor().putMessage("indentType", wrappingStyle.getFunctionDeclarationParameters().getUseContinuationIndent() ? IndentType.CONTINUATION_INDENT : IndentType.INDENT);
-//                    break;
                 case METHOD_INVOCATION_ARGUMENTS:
                 case NEW_CLASS_ARGUMENTS:
                     getCursor().putMessage("indentType", wrappingStyle.getFunctionCallArguments().getUseContinuationIndent() ? IndentType.CONTINUATION_INDENT : IndentType.INDENT);

--- a/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
 import org.openrewrite.kotlin.marker.Implicit;
 import org.openrewrite.kotlin.style.TabsAndIndentsStyle;
+import org.openrewrite.kotlin.style.WrappingAndBracesStyle;
 import org.openrewrite.kotlin.tree.K;
 
 import java.util.Iterator;
@@ -35,13 +36,15 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
     private final Tree stopAfter;
 
     private final TabsAndIndentsStyle style;
+    private final WrappingAndBracesStyle wrappingStyle;
 
-    public TabsAndIndentsVisitor(TabsAndIndentsStyle style) {
-        this(style, null);
+    public TabsAndIndentsVisitor(TabsAndIndentsStyle style, WrappingAndBracesStyle wrappingStyle) {
+        this(style, wrappingStyle, null);
     }
 
-    public TabsAndIndentsVisitor(TabsAndIndentsStyle style, @Nullable Tree stopAfter) {
+    public TabsAndIndentsVisitor(TabsAndIndentsStyle style, WrappingAndBracesStyle wrappingStyle, @Nullable Tree stopAfter) {
         this.style = style;
+        this.wrappingStyle = wrappingStyle;
         this.stopAfter = stopAfter;
     }
 
@@ -98,14 +101,17 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
                 tree instanceof J.ForEachLoop ||
                 tree instanceof J.WhileLoop ||
                 tree instanceof J.Case ||
-                tree instanceof J.EnumValueSet) {
+                tree instanceof J.EnumValueSet ||
+                (tree instanceof J.FieldAccess || tree instanceof J.MethodInvocation)
+                        && !wrappingStyle.getChainedFunctionCalls().getUseContinuationIndent()
+        ) {
             getCursor().putMessage("indentType", IndentType.INDENT);
         } else if (tree instanceof K.ExpressionStatement ||
-                   tree instanceof K.StatementExpression ||
-                   tree instanceof K.KReturn ||
-                   tree instanceof K.When ||
-                   tree instanceof K.WhenBranch ||
-                   (tree != null && tree.getMarkers().findFirst(ImplicitReturn.class).isPresent())) {
+                tree instanceof K.StatementExpression ||
+                tree instanceof K.KReturn ||
+                tree instanceof K.When ||
+                tree instanceof K.WhenBranch ||
+                (tree != null && tree.getMarkers().findFirst(ImplicitReturn.class).isPresent())) {
             // skip, do nothing
         } else {
             getCursor().putMessage("indentType", IndentType.CONTINUATION_INDENT);
@@ -145,7 +151,7 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
 
             if ((loc == Space.Location.CLASS_KIND ||
                     loc == Space.Location.METHOD_DECLARATION_PREFIX)
-                && getCursor().getValue() instanceof J.ClassDeclaration) {
+                    && getCursor().getValue() instanceof J.ClassDeclaration) {
                 J.ClassDeclaration c = getCursor().getValue();
                 if (!c.getLeadingAnnotations().isEmpty()) {
                     alignToAnnotation = true;
@@ -271,7 +277,8 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
                             }
                         } else {
                             elem = visitAndCast(elem, p);
-                            after = indentTo(right.getAfter(), t == lastArg ? indent : style.getContinuationIndent(), loc.getAfterLocation());
+                            Integer indentSize = wrappingStyle.getFunctionDeclarationParameters().getUseContinuationIndent() ? style.getContinuationIndent() : style.getIndentSize();
+                            after = indentTo(right.getAfter(), t == lastArg ? indent : indentSize, loc.getAfterLocation());
                         }
                         break;
                     }
@@ -314,7 +321,8 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
                         getCursor().getParentOrThrow().putMessage("lastIndent", indent);
                         elem = visitAndCast(elem, p);
                         after = visitSpace(right.getAfter(), loc.getAfterLocation(), p);
-                        getCursor().getParentOrThrow().putMessage("lastIndent", indent + style.getContinuationIndent());
+                        int increment = wrappingStyle.getChainedFunctionCalls().getUseContinuationIndent() ? style.getContinuationIndent() : style.getIndentSize();
+                        getCursor().getParentOrThrow().putMessage("lastIndent", indent + increment);
                         break;
                     }
                     case ANNOTATION_ARGUMENT:
@@ -336,6 +344,7 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
                 switch (loc) {
                     case NEW_CLASS_ARGUMENTS:
                     case METHOD_INVOCATION_ARGUMENT:
+                        int chainedIncrement = wrappingStyle.getChainedFunctionCalls().getUseContinuationIndent() ? style.getContinuationIndent() : style.getIndentSize();
                         if (!elem.getPrefix().getLastWhitespace().contains("\n")) {
                             JContainer<J> args = getCursor().getParentOrThrow().getValue();
                             boolean anyOtherArgOnOwnLine = false;
@@ -358,12 +367,12 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
                             if (!(elem instanceof J.MethodInvocation)) {
                                 getCursor().putMessage("lastIndent", indent + style.getContinuationIndent());
                             } else if (elem.getPrefix().getLastWhitespace().contains("\n")) {
-                                getCursor().putMessage("lastIndent", indent + style.getContinuationIndent());
+                                getCursor().putMessage("lastIndent", indent + chainedIncrement);
                             } else {
                                 J.MethodInvocation methodInvocation = (J.MethodInvocation) elem;
                                 Expression select = methodInvocation.getSelect();
                                 if (select instanceof J.FieldAccess || select instanceof J.Identifier || select instanceof J.MethodInvocation) {
-                                    getCursor().putMessage("lastIndent", indent + style.getContinuationIndent());
+                                    getCursor().putMessage("lastIndent", indent + chainedIncrement);
                                 }
                             }
                         }
@@ -396,14 +405,25 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
 
         int indent = getCursor().getNearestMessage("lastIndent", 0);
         if (container.getBefore().getLastWhitespace().contains("\n")) {
+            int increment;
+            switch (loc) {
+                case NEW_CLASS_ARGUMENTS:
+                case METHOD_INVOCATION_ARGUMENTS:
+                    increment = wrappingStyle.getFunctionCallArguments().getUseContinuationIndent() ? style.getContinuationIndent() : style.getIndentSize();
+                    break;
+                default:
+                    increment = style.getContinuationIndent();
+                    break;
+            }
             switch (loc) {
                 case TYPE_PARAMETERS:
                 case IMPLEMENTS:
                 case THROWS:
                 case NEW_CLASS_ARGUMENTS:
-                    before = indentTo(container.getBefore(), indent + style.getContinuationIndent(), loc.getBeforeLocation());
-                    getCursor().putMessage("indentType",  IndentType.ALIGN);
-                    getCursor().putMessage("lastIndent", indent + style.getContinuationIndent());
+                case METHOD_INVOCATION_ARGUMENTS:
+                    before = indentTo(container.getBefore(), indent + increment, loc.getBeforeLocation());
+                    getCursor().putMessage("indentType", IndentType.ALIGN);
+                    getCursor().putMessage("lastIndent", indent + increment);
                     js = ListUtils.map(container.getPadding().getElements(), t -> visitRightPadded(t, loc.getElementLocation(), p));
                     break;
                 default:
@@ -413,18 +433,22 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
         } else {
             switch (loc) {
                 case IMPLEMENTS:
+                    getCursor().putMessage("indentType", wrappingStyle.getExtendsImplementsPermitsList().getUseContinuationIndent() ? IndentType.CONTINUATION_INDENT : IndentType.INDENT);
+                    break;
+//                case METHOD_DECLARATION_PARAMETERS:
+//                    getCursor().putMessage("indentType", wrappingStyle.getFunctionDeclarationParameters().getUseContinuationIndent() ? IndentType.CONTINUATION_INDENT : IndentType.INDENT);
+//                    break;
                 case METHOD_INVOCATION_ARGUMENTS:
                 case NEW_CLASS_ARGUMENTS:
+                    getCursor().putMessage("indentType", wrappingStyle.getFunctionCallArguments().getUseContinuationIndent() ? IndentType.CONTINUATION_INDENT : IndentType.INDENT);
+                    break;
                 case TYPE_PARAMETERS:
                 case THROWS:
                     getCursor().putMessage("indentType", IndentType.CONTINUATION_INDENT);
-                    before = visitSpace(container.getBefore(), loc.getBeforeLocation(), p);
-                    js = ListUtils.map(container.getPadding().getElements(), t -> visitRightPadded(t, loc.getElementLocation(), p));
                     break;
-                default:
-                    before = visitSpace(container.getBefore(), loc.getBeforeLocation(), p);
-                    js = ListUtils.map(container.getPadding().getElements(), t -> visitRightPadded(t, loc.getElementLocation(), p));
             }
+            before = visitSpace(container.getBefore(), loc.getBeforeLocation(), p);
+            js = ListUtils.map(container.getPadding().getElements(), t -> visitRightPadded(t, loc.getElementLocation(), p));
         }
 
         setCursor(getCursor().getParent());
@@ -543,7 +567,7 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
                         char c = chars[i];
                         if (c == '\n') {
                             multiline.append(c);
-                            for (int j = 0; j < Math.abs(shift) && i+j+1 < chars.length && (chars[j + i + 1] == ' ' || chars[j + i + 1] == '\t'); j++) {
+                            for (int j = 0; j < Math.abs(shift) && i + j + 1 < chars.length && (chars[j + i + 1] == ' ' || chars[j + i + 1] == '\t'); j++) {
                                 i++;
                             }
                         } else {
@@ -558,12 +582,12 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
         } else if (comment instanceof Javadoc.DocComment) {
             final Javadoc.DocComment docComment = (Javadoc.DocComment) comment;
             return docComment.withBody(ListUtils.map(docComment.getBody(), (i, jdoc) -> {
-                if(!(jdoc instanceof Javadoc.LineBreak)) {
+                if (!(jdoc instanceof Javadoc.LineBreak)) {
                     return jdoc;
                 }
                 Javadoc.LineBreak lineBreak = (Javadoc.LineBreak) jdoc;
                 String linebreak;
-                if(lineBreak.getMargin().charAt(0) == '\r') {
+                if (lineBreak.getMargin().charAt(0) == '\r') {
                     linebreak = "\r\n";
                 } else {
                     linebreak = "\n";
@@ -619,7 +643,8 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
         }
 
         int size = 0;
-        for (char c : whitespace.toCharArray()) {
+        for (int i = 0; i < whitespace.length(); i++) {
+            char c = whitespace.charAt(i);
             size += c == '\t' ? style.getTabSize() : 1;
             if (c == '\n' || c == '\r') {
                 size = 0;

--- a/src/main/java/org/openrewrite/kotlin/style/IntelliJ.java
+++ b/src/main/java/org/openrewrite/kotlin/style/IntelliJ.java
@@ -58,6 +58,7 @@ public class IntelliJ extends NamedStyles {
 
     public static ImportLayoutStyle importLayout() {
         return ImportLayoutStyle.builder()
+                .packageToFold("java.util.*", true)
                 .packageToFold("kotlinx.android.synthetic.*", true)
                 .packageToFold("io.ktor.*", true)
                 .importAllOthers()
@@ -101,7 +102,9 @@ public class IntelliJ extends NamedStyles {
                 new WrappingAndBracesStyle.TryStatement(false, false),
                 new WrappingAndBracesStyle.BinaryExpression(false),
                 new WrappingAndBracesStyle.WhenStatements(false, true),
-                new WrappingAndBracesStyle.BracesPlacement(false)
+                new WrappingAndBracesStyle.BracesPlacement(false),
+                new WrappingAndBracesStyle.ExpressionBodyFunctions(false),
+                new WrappingAndBracesStyle.ElvisExpressions(false)
         );
     }
 

--- a/src/main/java/org/openrewrite/kotlin/style/IntelliJ.java
+++ b/src/main/java/org/openrewrite/kotlin/style/IntelliJ.java
@@ -58,7 +58,7 @@ public class IntelliJ extends NamedStyles {
 
     public static ImportLayoutStyle importLayout() {
         return ImportLayoutStyle.builder()
-                .packageToFold("java.util.*", true)
+//                .packageToFold("java.util.*", true)
                 .packageToFold("kotlinx.android.synthetic.*", true)
                 .packageToFold("io.ktor.*", true)
                 .importAllOthers()

--- a/src/main/java/org/openrewrite/kotlin/style/WrappingAndBracesStyle.java
+++ b/src/main/java/org/openrewrite/kotlin/style/WrappingAndBracesStyle.java
@@ -18,6 +18,8 @@ package org.openrewrite.kotlin.style;
 import lombok.Value;
 import lombok.With;
 import org.openrewrite.kotlin.KotlinStyle;
+import org.openrewrite.style.Style;
+import org.openrewrite.style.StyleHelper;
 
 @Value
 @With
@@ -133,5 +135,10 @@ public class WrappingAndBracesStyle implements KotlinStyle {
     @With
     public static class ElvisExpressions {
         Boolean useContinuationIndent;
+    }
+
+    @Override
+    public Style applyDefaults() {
+        return StyleHelper.merge(IntelliJ.wrappingAndBraces(), this);
     }
 }

--- a/src/main/java/org/openrewrite/kotlin/style/WrappingAndBracesStyle.java
+++ b/src/main/java/org/openrewrite/kotlin/style/WrappingAndBracesStyle.java
@@ -35,6 +35,8 @@ public class WrappingAndBracesStyle implements KotlinStyle {
     BinaryExpression binaryExpression;
     WhenStatements whenStatements;
     BracesPlacement bracesPlacement;
+    ExpressionBodyFunctions expressionBodyFunctions;
+    ElvisExpressions elvisExpressions;
 
     @Value
     @With
@@ -119,5 +121,17 @@ public class WrappingAndBracesStyle implements KotlinStyle {
     @With
     public static class BracesPlacement {
         Boolean putLeftBraceOnNewLine;
+    }
+
+    @Value
+    @With
+    public static class ExpressionBodyFunctions {
+        Boolean useContinuationIndent;
+    }
+
+    @Value
+    @With
+    public static class ElvisExpressions {
+        Boolean useContinuationIndent;
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/format/AutoFormatVisitorTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/AutoFormatVisitorTest.java
@@ -166,7 +166,7 @@ class AutoFormatVisitorTest implements RewriteTest {
                           bar: String
                   ) {
                       foo
-                              .length
+                          .length
                   }
 
                   fun expressionBodyMethod() =

--- a/src/test/java/org/openrewrite/kotlin/format/TabsAndIndentsTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/TabsAndIndentsTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.style.IntelliJ;
 import org.openrewrite.kotlin.style.TabsAndIndentsStyle;
+import org.openrewrite.kotlin.style.WrappingAndBracesStyle;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -42,15 +43,26 @@ class TabsAndIndentsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(IntelliJ.tabsAndIndents())));
+        spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(IntelliJ.tabsAndIndents(), IntelliJ.wrappingAndBraces())));
     }
 
     private static Consumer<RecipeSpec> tabsAndIndents(UnaryOperator<TabsAndIndentsStyle> with) {
-        return spec -> spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(with.apply(IntelliJ.tabsAndIndents()))))
+        return spec -> spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(with.apply(IntelliJ.tabsAndIndents()), IntelliJ.wrappingAndBraces())))
           .parser(KotlinParser.builder().styles(singletonList(
             new NamedStyles(
               Tree.randomId(), "test", "test", "test", emptySet(),
               singletonList(with.apply(IntelliJ.tabsAndIndents()))
+            )
+          )));
+    }
+
+    private static Consumer<RecipeSpec> style(UnaryOperator<TabsAndIndentsStyle> tabsAndIndents, UnaryOperator<WrappingAndBracesStyle> wrappingAndBraces) {
+        return spec -> spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(
+            tabsAndIndents.apply(IntelliJ.tabsAndIndents()), wrappingAndBraces.apply(IntelliJ.wrappingAndBraces()))))
+          .parser(KotlinParser.builder().styles(singletonList(
+            new NamedStyles(
+              Tree.randomId(), "test", "test", "test", emptySet(),
+              singletonList(tabsAndIndents.apply(IntelliJ.tabsAndIndents()))
             )
           )));
     }
@@ -298,14 +310,17 @@ class TabsAndIndentsTest implements RewriteTest {
     @Test
     void methodChain() {
         rewriteRun(
-          tabsAndIndents(style -> style.withContinuationIndent(2)),
+          style(
+            style -> style.withContinuationIndent(2),
+            style -> style.withChainedFunctionCalls(style.getChainedFunctionCalls().withUseContinuationIndent(true))
+          ),
           kotlin(
             """
               class Test {
                   fun method(t: Test) {
                       this
                         .method(
-                          t
+                            t
                         );
                   }
               }
@@ -350,11 +365,11 @@ class TabsAndIndentsTest implements RewriteTest {
 
                   fun method(t: Test) {
                       var t1 = t.withData(withData()
-                                      .withData()
-                                      .withData(),
-                              withData()
-                                      .withData()
-                                      .withData()
+                              .withData()
+                              .withData(),
+                          withData()
+                              .withData()
+                              .withData()
                       )
                   }
               }
@@ -375,9 +390,9 @@ class TabsAndIndentsTest implements RewriteTest {
 
                   fun method(t: Test) {
                       var t1 = t.withData(
-                              withData(), withData()
-                              .withData()
-                              .withData()
+                          withData(), withData()
+                          .withData()
+                          .withData()
                       );
                   }
               }
@@ -399,15 +414,15 @@ class TabsAndIndentsTest implements RewriteTest {
 
                   fun method(t: Test) {
                       var t1 = t.withData(withData()
-                              .withData(t
-                                      .
-                                              withData()
-                              )
-                              .withData(
-                                      t
-                                              .
-                                                      withData()
-                              )
+                          .withData(t
+                              .
+                                  withData()
+                          )
+                          .withData(
+                              t
+                                  .
+                                      withData()
+                          )
                       );
                   }
               }
@@ -527,7 +542,7 @@ class TabsAndIndentsTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              import java.util.Collection;
+              import java.util.Collection
 
               class Test {
                   fun withData(vararg arg0: Any): Test {
@@ -583,7 +598,7 @@ class TabsAndIndentsTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              import java.util.function.Predicate;
+              import java.util.function.Predicate
 
               class SomeUtility {
                   fun test(property: String, test: Predicate<String>): Boolean {
@@ -597,7 +612,7 @@ class TabsAndIndentsTest implements RewriteTest {
               class Test {
                   fun method() {
                       SomeUtility().test(
-                              "hello", { s ->
+                          "hello", { s ->
                                   true
                               })
                   }
@@ -613,8 +628,8 @@ class TabsAndIndentsTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              import java.util.*;
-              import java.util.stream.Collectors;
+              import java.util.*
+              import java.util.stream.Collectors
 
               class Test {
                   fun method(c: Collection<List<String>>) {
@@ -623,7 +638,7 @@ class TabsAndIndentsTest implements RewriteTest {
                               0
                           }
                       }
-                              .collect(Collectors.toList());
+                          .collect(Collectors.toList());
                   }
               }
               """
@@ -643,12 +658,12 @@ class TabsAndIndentsTest implements RewriteTest {
               class Test {
                   fun method(c: Collection<List<String>>) {
                       c.stream()
-                              .map { x ->
-                                  x.stream().max { r1, r2 ->
-                                      0
-                                  }
+                          .map { x ->
+                              x.stream().max { r1, r2 ->
+                                  0
                               }
-                              .collect(Collectors.toList())
+                          }
+                          .collect(Collectors.toList())
                   }
               }
               """
@@ -715,11 +730,11 @@ class TabsAndIndentsTest implements RewriteTest {
                   }
 
                   fun multilineMethod(
-                          foo: String,
-                          bar: String
+                      foo: String,
+                      bar: String
                   ) {
                       foo
-                              .length
+                          .length
                   }
 
                   fun expressionBodyMethod() =
@@ -1019,7 +1034,7 @@ class TabsAndIndentsTest implements RewriteTest {
           kotlin(
             """
               annotation class Anno
-              
+                            
               class Test {
                   @Suppress(
                           "unchecked"
@@ -1038,7 +1053,7 @@ class TabsAndIndentsTest implements RewriteTest {
           kotlin(
             """
               annotation class Anno
-              
+                            
               @Suppress("A")
               @Anno
                  class A {
@@ -1050,7 +1065,7 @@ class TabsAndIndentsTest implements RewriteTest {
               """,
             """
               annotation class Anno
-              
+                            
               @Suppress("A")
               @Anno
               class A {
@@ -1298,7 +1313,7 @@ class TabsAndIndentsTest implements RewriteTest {
                   fun method(t: Test) {
                       method(Test("hello" +
                               "world",
-                              1))
+                          1))
                   }
               }
               """
@@ -1311,32 +1326,32 @@ class TabsAndIndentsTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              import java.io.File;
+              import java.io.File
               class Test {
                   fun method(n: Int,f: File,m: Int,l: Int) {
                       method(n, File(
-                                      "test"
+                                  "test"
                               ),
-                              m,
-                              l)
+                          m,
+                          l)
                   }
 
                   fun method2(n: Int,f: File,m: Int) {
                       method(n, File(
-                                      "test"
+                                  "test"
                               ), m,
-                              0)
+                          0)
                   }
 
                   fun method3(n: Int,f: File) {
                       method2(n, File(
-                              "test"
+                          "test"
                       ), 0)
                   }
 
                   fun method4(n: Int) {
                       method3(n, File(
-                              "test"
+                          "test"
                       ))
                   }
               }
@@ -1353,12 +1368,12 @@ class TabsAndIndentsTest implements RewriteTest {
               class Test {
                   fun method5(n: Int, m: Int) {
                       method5(1,
-                              2);
+                          2);
                       return method5(method5(method5(method5(3,
-                              4),
-                              5),
-                              6),
-                              7);
+                          4),
+                          5),
+                          6),
+                          7);
                   }
               }
               """
@@ -1371,20 +1386,20 @@ class TabsAndIndentsTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              import java.util.stream.Stream;
+              import java.util.stream.Stream
 
               class Test {
                   var t: Test = this;
                   fun method(n: Stream<*>?,m: Int): Test {
                       this.t.t
-                              .method(null, 1)
-                              .t
-                              .method(null, 2);
+                          .method(null, 1)
+                          .t
+                          .method(null, 2);
                       Stream
-                              .of("a");
+                          .of("a");
                       method(Stream
-                                      .of("a"),
-                              3
+                              .of("a"),
+                          3
                       );
                       return this
                   }
@@ -1436,7 +1451,7 @@ class TabsAndIndentsTest implements RewriteTest {
                       method({ ->
                                   "hi"
                               },
-                              n);
+                          n);
                   }
               }
               """
@@ -1564,14 +1579,14 @@ class TabsAndIndentsTest implements RewriteTest {
               class Test {
                   fun method(n: Int): Test {
                       return method(n)
-                              .method(n)
-                              .method(n);
+                          .method(n)
+                          .method(n);
                   }
 
                   fun method2(): Test {
                       return method2().
-                              method2().
-                              method2();
+                          method2().
+                          method2();
                   }
               }
               """
@@ -1585,15 +1600,15 @@ class TabsAndIndentsTest implements RewriteTest {
           kotlin(
             """
               import java.io.File
-              
+                            
               class Test {
                   fun method(m: Int, f: File, f2: File) {
                       method(m, File(
-                                      "test"
+                                  "test"
                               ), 
-                              File("test", 
-                                      "test"
-                              ))
+                          File("test", 
+                              "test"
+                          ))
                   }
               }
               """
@@ -1624,18 +1639,18 @@ class TabsAndIndentsTest implements RewriteTest {
           kotlin(
             """
               import java.util.function.Function
-              
+                            
               abstract class Test {
                   abstract fun a(f: Function<Test, Test>): Test
                   abstract fun b(f: Function<Test, Test>): Test
                   abstract fun c(f: Function<Test, Test>): Test
-              
+                            
                   fun method(f: Function<Test, Test>): Test {
                       return a(f)
-                              .b { 
-                                      t ->
-                                  c(f)
-                              }
+                          .b { 
+                                  t ->
+                              c(f)
+                          }
                   }
               }
               """
@@ -1649,17 +1664,17 @@ class TabsAndIndentsTest implements RewriteTest {
           kotlin(
             """
               import java.util.function.Function
-              
+                            
               abstract class Test {
                   abstract fun a(f: Function<Test, Test>): Test
                   abstract fun b(f: Function<Test, Test>): Test
                   abstract fun c(f: Function<Test, Test>): Test
-              
+                            
                   fun method(f: Function<Test, Test>): Test {
                       return a(f)
-                              .b {t ->
-                                  c(f)
-                              }
+                          .b {t ->
+                              c(f)
+                          }
                   }
               }
               """
@@ -1674,14 +1689,14 @@ class TabsAndIndentsTest implements RewriteTest {
           kotlin(
             """
               import java.util.stream.Stream
-              
+                            
               class Test {
                   var b: Boolean = false
                   fun method(): Stream<Test> {
                       if (b && method()
-                              .anyMatch { t -> b || 
-                                      b
-                              }) {
+                          .anyMatch { t -> b || 
+                                  b
+                          }) {
                           // do nothing
                       }
                       return Stream.of(this)
@@ -1701,26 +1716,12 @@ class TabsAndIndentsTest implements RewriteTest {
               class Test {
                   constructor(t: Test)
                   constructor()
-              
+                            
                   fun method(t: Test) {
                       method(
                           Test(
                               Test()
                           )
-                      )
-                  }
-              }
-              """,
-            """
-              class Test {
-                  constructor(t: Test)
-                  constructor()
-              
-                  fun method(t: Test) {
-                      method(
-                              Test(
-                                      Test()
-                              )
                       )
                   }
               }
@@ -2060,8 +2061,8 @@ class TabsAndIndentsTest implements RewriteTest {
             """),
           kotlin(
             """
-              package org.b;
-              import org.a.A;
+              package org.b
+              import org.a.A
               class B
                   : A() {
               }
@@ -2070,7 +2071,7 @@ class TabsAndIndentsTest implements RewriteTest {
         );
     }
 
-//
+    //
     @Issue("https://github.com/openrewrite/rewrite/issues/1526")
     @Test
     void doNotFormatSingleLineCommentAtCol0() {

--- a/src/test/java/org/openrewrite/kotlin/format/WrappingAndBracesTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/WrappingAndBracesTest.java
@@ -48,7 +48,7 @@ class WrappingAndBracesTest implements RewriteTest {
         return spec -> spec
           .recipes(
             toRecipe(() -> new WrappingAndBracesVisitor<>(wrapping.apply(IntelliJ.wrappingAndBraces()))),
-            toRecipe(() -> new TabsAndIndentsVisitor<>(IntelliJ.tabsAndIndents())),
+            toRecipe(() -> new TabsAndIndentsVisitor<>(IntelliJ.tabsAndIndents(), IntelliJ.wrappingAndBraces())),
             toRecipe(() -> new SpacesVisitor<>(spaces.apply(IntelliJ.spaces())))
           )
           .parser(KotlinParser.builder().styles(singletonList(


### PR DESCRIPTION
`WrappingAndBraces` now has `ExpressionBodyFunctions(boolean useContinuationIndent)` and `ElvisExpressions(boolean useContinuationIndent)`
