### PR TITLE
To support seperate alias import

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/format/AutoFormatVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/AutoFormatVisitor.java
@@ -80,6 +80,7 @@ public class AutoFormatVisitor<P> extends KotlinIsoVisitor<P> {
 
         t = new RemoveTrailingWhitespaceVisitor<>(stopAfter).visit(t, p, cursor.fork());
 
+        t = new ImportReorderingVisitor<>().visit(t, p, cursor.fork());
         return t;
     }
 

--- a/src/main/java/org/openrewrite/kotlin/format/ImportReorderingVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/ImportReorderingVisitor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.format;
+
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.style.ImportLayoutStyle;
+import org.openrewrite.kotlin.style.IntelliJ;
+import org.openrewrite.kotlin.tree.K;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+public class ImportReorderingVisitor<P> extends KotlinIsoVisitor<P> {
+
+    @Override
+    public K.CompilationUnit visitCompilationUnit(K.CompilationUnit cu, P p) {
+        List<JRightPadded<J.Import>> importList = cu.getPadding().getImports();
+
+        ImportLayoutStyle layoutStyle = Optional.ofNullable(cu.getStyle(ImportLayoutStyle.class))
+                .orElse(IntelliJ.importLayout());
+
+        List<JRightPadded<J.Import>> ordered = layoutStyle.orderImports(importList, new HashSet<>());
+
+        if (referentialIdentical(importList, ordered)) {
+            return cu;
+        } else {
+            return cu.getPadding().withImports(ordered);
+        }
+    }
+
+    private <T> boolean referentialIdentical(List<T> l1, List<T> l2) {
+        if (l1.size() != l2.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < l1.size(); i++) {
+            if (l1.get(i) != l2.get(i)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/openrewrite/kotlin/style/ImportLayoutStyle.java
+++ b/src/main/java/org/openrewrite/kotlin/style/ImportLayoutStyle.java
@@ -83,7 +83,13 @@ public class ImportLayoutStyle implements KotlinStyle {
     private final List<Block> blocksNoCatchalls;
     private final List<Block> blocksOnlyCatchalls;
 
-    public ImportLayoutStyle(int topLevelSymbolsToUseStarImport, int javaStaticsAndEnumsToUseStarImport, List<Block> layout, List<Block> packagesToFold) {
+    private final boolean importAliasesSeparately;
+
+    public ImportLayoutStyle(int topLevelSymbolsToUseStarImport,
+                             int javaStaticsAndEnumsToUseStarImport,
+                             List<Block> layout,
+                             List<Block> packagesToFold,
+                             boolean importAliasesSeparately) {
         this.topLevelSymbolsToUseStarImport = topLevelSymbolsToUseStarImport;
         this.javaStaticsAndEnumsToUseStarImport = javaStaticsAndEnumsToUseStarImport;
         this.layout = layout.isEmpty() ? IntelliJ.importLayout().getLayout() : layout;
@@ -94,6 +100,9 @@ public class ImportLayoutStyle implements KotlinStyle {
                 .collect(Collectors.partitioningBy(Block.AllOthers.class::isInstance));
         blocksNoCatchalls = blockGroups.get(false);
         blocksOnlyCatchalls = blockGroups.get(true);
+
+        // This setting is by default enabled on Intellij's UI, but in reality, it's turned off.
+        this.importAliasesSeparately = importAliasesSeparately;
     }
 
     /**
@@ -124,7 +133,7 @@ public class ImportLayoutStyle implements KotlinStyle {
         // the import to add at most. we don't even want to star fold other non-adjacent imports in the same
         // block that should be star folded according to the layout style (minimally invasive change).
         List<JRightPadded<J.Import>> ideallyOrdered =
-                new ImportLayoutStyle(Integer.MAX_VALUE, Integer.MAX_VALUE, layout, packagesToFold)
+                new ImportLayoutStyle(Integer.MAX_VALUE, Integer.MAX_VALUE, layout, packagesToFold, importAliasesSeparately)
                         .orderImports(ListUtils.concat(originalImports, paddedToAdd), new HashSet<>());
 
         if (ideallyOrdered.size() == originalImports.size()) {
@@ -394,9 +403,10 @@ public class ImportLayoutStyle implements KotlinStyle {
         private final List<Block> packagesToFold = new ArrayList<>();
         private int topLevelSymbolsToUseStarImport = 5;
         private int javaStaticsAndEnumsToUseStarImport = 3;
+        private boolean importAliasesSeparately = false;
 
         public Builder importAllOthers() {
-            blocks.add(new Block.AllOthers());
+            blocks.add(new Block.AllOthers(!importAliasesSeparately));
             return this;
         }
 
@@ -416,7 +426,7 @@ public class ImportLayoutStyle implements KotlinStyle {
         }
 
         public Builder importPackage(String packageWildcard, Boolean withSubpackages) {
-            blocks.add(new Block.ImportPackage(packageWildcard, withSubpackages));
+            blocks.add(new Block.ImportPackage(packageWildcard, withSubpackages, !importAliasesSeparately));
             return this;
         }
 
@@ -425,7 +435,7 @@ public class ImportLayoutStyle implements KotlinStyle {
         }
 
         public Builder packageToFold(String packageWildcard, Boolean withSubpackages) {
-            packagesToFold.add(new Block.ImportPackage(packageWildcard, withSubpackages));
+            packagesToFold.add(new Block.ImportPackage(packageWildcard, withSubpackages, !importAliasesSeparately));
             return this;
         }
 
@@ -443,6 +453,11 @@ public class ImportLayoutStyle implements KotlinStyle {
             return this;
         }
 
+        public Builder importAliasesSeparately(boolean importAliasesSeparately) {
+            this.importAliasesSeparately = importAliasesSeparately;
+            return this;
+        }
+
         public ImportLayoutStyle build() {
             for (Block block : blocks) {
                 if (block instanceof Block.AllOthers) {
@@ -452,7 +467,7 @@ public class ImportLayoutStyle implements KotlinStyle {
                             .collect(toList()));
                 }
             }
-            return new ImportLayoutStyle(topLevelSymbolsToUseStarImport, javaStaticsAndEnumsToUseStarImport, blocks, packagesToFold);
+            return new ImportLayoutStyle(topLevelSymbolsToUseStarImport, javaStaticsAndEnumsToUseStarImport, blocks, packagesToFold, importAliasesSeparately);
         }
     }
 
@@ -611,6 +626,7 @@ public class ImportLayoutStyle implements KotlinStyle {
 
         @SuppressWarnings("deprecation")
         class ImportPackage implements Block {
+            boolean acceptAliasImport;
 
             // VisibleForTesting
             static final Comparator<JRightPadded<J.Import>> IMPORT_SORTING = (i1, i2) -> {
@@ -633,7 +649,8 @@ public class ImportLayoutStyle implements KotlinStyle {
 
             private final Pattern packageWildcard;
 
-            public ImportPackage(String packageWildcard, boolean withSubpackages) {
+            public ImportPackage(String packageWildcard, boolean withSubpackages, boolean acceptAliasImport) {
+                this.acceptAliasImport = acceptAliasImport;
                 this.packageWildcard = Pattern.compile(packageWildcard
                         .replace(".", "\\.")
                         .replace("*", withSubpackages ? ".+" : "[^.]+"));
@@ -645,7 +662,11 @@ public class ImportLayoutStyle implements KotlinStyle {
 
             @Override
             public boolean accept(JRightPadded<J.Import> anImport) {
-                return anImport.getElement().getAlias() == null && packageWildcard.matcher(anImport.getElement().getQualid().printTrimmed()).matches();
+                if ((!acceptAliasImport) && (anImport.getElement().getAlias() != null)) {
+                    return false;
+                }
+
+                return packageWildcard.matcher(anImport.getElement().getQualid().printTrimmed()).matches();
             }
 
             @Override
@@ -717,8 +738,8 @@ public class ImportLayoutStyle implements KotlinStyle {
         class AllOthers extends ImportPackage {
             private Collection<ImportPackage> packageImports = emptyList();
 
-            public AllOthers() {
-                super("*", true);
+            public AllOthers(boolean acceptAlias) {
+                super("*", true, acceptAlias);
             }
 
             public void setPackageImports(Collection<ImportPackage> packageImports) {
@@ -745,7 +766,7 @@ public class ImportLayoutStyle implements KotlinStyle {
             private Collection<ImportPackage> packageImports = emptyList();
 
             public AllAliases() {
-                super("*", true);
+                super("*", true, true);
             }
 
             public void setPackageImports(Collection<ImportPackage> packageImports) {

--- a/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -15,12 +15,18 @@
  */
 package org.openrewrite.kotlin;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.kotlin.style.ImportLayoutStyle;
 import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -147,7 +153,13 @@ public class AddImportTest implements RewriteTest {
     @Test
     void importAlias() {
         rewriteRun(
-          spec -> spec.recipe(importMemberRecipe("java.util.regex.Pattern", "MULTILINE")),
+          spec -> spec.recipe(importMemberRecipe("java.util.regex.Pattern", "MULTILINE"))
+            .parser(KotlinParser.builder().styles(singletonList(
+            new NamedStyles(
+              randomId(), "test", "test", "test", emptySet(),
+              singletonList(importAliasesSeparatelyStyle())
+            )
+          ))),
           kotlin(
             """
               import java.util.regex.Pattern.CASE_INSENSITIVE as i
@@ -237,18 +249,51 @@ public class AddImportTest implements RewriteTest {
           ),
           kotlin(
             """
-              import java.util.Calendar
-              
-              import java.util.HashMap as MyHashMap
+              import java.util.Calendar as CA
+              import java.util.HashMap
               import java.util.StringJoiner as MyStringJoiner
 
               class A {
               }
               """,
             """
-              import java.util.Calendar
+              import java.util.Calendar as CA
+              import java.util.HashMap
+              import java.util.LinkedList as MyList
+              import java.util.StringJoiner as MyStringJoiner
+
+              class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void importOrderingWithAliasImportAliasesSeparately() {
+        rewriteRun(
+          spec -> spec.recipe(
+            importTypeRecipe("java.util", "LinkedList", "MyList")
+          ).parser(KotlinParser.builder().styles(singletonList(
+            new NamedStyles(
+              randomId(), "test", "test", "test", emptySet(),
+              singletonList(importAliasesSeparatelyStyle())
+            )
+          ))),
+          kotlin(
+            """
+              import java.util.HashMap
               
-              import java.util.HashMap as MyHashMap
+              import java.util.Calendar as CA
+              import java.util.StringJoiner as MyStringJoiner
+
+              class A {
+              }
+              """,
+            """
+              import java.util.HashMap
+              
+              import java.util.Calendar as CA
               import java.util.LinkedList as MyList
               import java.util.StringJoiner as MyStringJoiner
 
@@ -325,5 +370,19 @@ public class AddImportTest implements RewriteTest {
                 return cu;
             }
         });
+    }
+
+    static ImportLayoutStyle importAliasesSeparatelyStyle() {
+        // same style as `IntelliJ.importLayout()` but just with `importAliasesSeparately` as false
+        return ImportLayoutStyle.builder()
+          .importAliasesSeparately(true)
+          .packageToFold("kotlinx.android.synthetic.*", true)
+          .packageToFold("io.ktor.*", true)
+          .importAllOthers()
+          .importPackage("java.*")
+          .importPackage("javax.*")
+          .importPackage("kotlin.*")
+          .importAllAliases()
+          .build();
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.kotlin;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
@@ -372,7 +371,7 @@ public class AddImportTest implements RewriteTest {
         });
     }
 
-    static ImportLayoutStyle importAliasesSeparatelyStyle() {
+    public static ImportLayoutStyle importAliasesSeparatelyStyle() {
         // same style as `IntelliJ.importLayout()` but just with `importAliasesSeparately` as false
         return ImportLayoutStyle.builder()
           .importAliasesSeparately(true)

--- a/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -233,9 +233,8 @@ class ChangeTypeTest implements RewriteTest {
           spec -> spec.recipe(new ChangeType("java.util.ArrayList", "java.util.LinkedList", true)),
           kotlin(
             """
-              import java.util.ArrayList
-
               import java.util.ArrayList as MyList
+              import java.util.ArrayList
 
               fun main() {
                   val list = ArrayList<String>()
@@ -243,9 +242,8 @@ class ChangeTypeTest implements RewriteTest {
               }
               """,
             """
-              import java.util.LinkedList
-              
               import java.util.LinkedList as MyList
+              import java.util.LinkedList
 
               fun main() {
                   val list = LinkedList<String>()
@@ -271,9 +269,8 @@ class ChangeTypeTest implements RewriteTest {
               }
               """,
             """
-              import java.util.LinkedList
-              
               import java.util.LinkedList as MyList
+              import java.util.LinkedList
 
               fun main() {
                   val list = LinkedList<String>()


### PR DESCRIPTION
To support Intellij's Kotlin import layout import aliases separately feature,
![Screenshot 2023-09-29 at 11 51 25 AM](https://github.com/openrewrite/rewrite-kotlin/assets/122563761/bc879621-9c26-4576-9a86-b3c9206ffb6f)

This setting is by default enabled on the UI but in reality, it's off by default (no change if you auto-format your code) in the IDE. so we set it to false as default, so by default, when adding an alias import, it will be added at the proper position.

