### PR TITLE
Type attribution fixes

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -561,6 +561,8 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession) : JavaTypeS
             if (owner.contains("<")) {
                 owner = owner.substring(0, owner.indexOf('<'))
             }
+        } else if (ownerSymbol is FirFunctionSymbol<*>) {
+            owner = methodDeclarationSignature(ownerSymbol, null)
         } else if (ownerSymbol != null) {
             owner = classSignature(ownerSymbol.fir)
         }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -112,10 +112,19 @@ public class KotlinTypeMappingTest {
         assertThat(id.getType()).isInstanceOf(JavaType.Class.class);
         assertThat(id.getType().toString()).isEqualTo("kotlin.Int");
 
-        assertThat(property.getGetter().getMethodType().toString().substring(property.getGetter().getMethodType().toString().indexOf("openRewriteFileKt"))).isEqualTo("openRewriteFileKt{name=accessor,return=kotlin.Int,parameters=[]}");
+
+        JavaType.FullyQualified declaringType = property.getGetter().getMethodType().getDeclaringType();
+        assertThat(declaringType.getFullyQualifiedName()).isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat");
+        assertThat(property.getGetter().getMethodType().getName()).isEqualTo("accessor");
+        assertThat(property.getGetter().getMethodType().getReturnType()).isEqualTo(id.getType());
         assertThat(property.getGetter().getMethodType()).isEqualTo(property.getGetter().getName().getType());
-        assertThat(property.getSetter().getMethodType().toString().substring(property.getGetter().getMethodType().toString().indexOf("openRewriteFileKt"))).isEqualTo("openRewriteFileKt{name=accessor,return=kotlin.Unit,parameters=[kotlin.Int]}");
+        assertThat(property.getGetter().getMethodType().toString().substring(declaringType.toString().length())).isEqualTo("{name=accessor,return=kotlin.Int,parameters=[]}");
+
+        declaringType = property.getSetter().getMethodType().getDeclaringType();
+        assertThat(declaringType.getFullyQualifiedName()).isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat");
+        assertThat(property.getSetter().getMethodType().getName()).isEqualTo("accessor");
         assertThat(property.getSetter().getMethodType()).isEqualTo(property.getSetter().getName().getType());
+        assertThat(property.getSetter().getMethodType().toString().substring(declaringType.toString().length())).isEqualTo("{name=accessor,return=kotlin.Unit,parameters=[kotlin.Int]}");
     }
 
     @Test


### PR DESCRIPTION
The owner of a `JavaType.Variable` is a `JavaType.Method` instance when the variable is a parameter or a local variable. It is only a `JavaType.Class` otherwise (typically in the case of a class field).
