### PR TITLE
File owner types

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
@@ -20,7 +20,9 @@ package org.openrewrite.kotlin
 
 import java.lang.Object
 
-// TODO: FIX ME. Files needs to declare fields and methods to assert type mapping.
+const val field = 10
+fun function() {}
+
 @AnnotationWithRuntimeRetention
 @AnnotationWithSourceRetention
 abstract class KotlinTypeGoat<T, S> where S: PT<S>, S: C {

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -577,6 +577,8 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession) : JavaTypeS
             }
         } else if (ownerSymbol is FirFunctionSymbol<*>) {
             owner = methodDeclarationSignature(ownerSymbol, null)
+        } else if (ownerSymbol is FirFileSymbol) {
+            owner = convertFileNameToFqn(ownerSymbol.fir.name)
         } else if (ownerSymbol != null) {
             owner = classSignature(ownerSymbol.fir)
         }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
@@ -44,7 +44,7 @@ public class KotlinTypeSignatureBuilderTest {
             .moduleName("test")
             .build()
             .parse(singletonList(new Parser.Input(Paths.get("KotlinTypeGoat.kt"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))), disposable,
-                    new ParsingExecutionContextView(new InMemoryExecutionContext(Throwable::printStackTrace)));;
+                    new ParsingExecutionContextView(new InMemoryExecutionContext(Throwable::printStackTrace)));
 
     @AfterAll
     static void afterAll() {
@@ -63,6 +63,7 @@ public class KotlinTypeSignatureBuilderTest {
 
     public String constructorSignature() {
         return signatureBuilder().methodDeclarationSignature(getCompiledSource().getDeclarations().stream()
+                .filter(FirRegularClass.class::isInstance)
                 .map(FirRegularClass.class::cast)
                 .flatMap(it -> it.getDeclarations().stream())
                 .filter(FirConstructor.class::isInstance)
@@ -74,6 +75,7 @@ public class KotlinTypeSignatureBuilderTest {
 
     public Object innerClassSignature(String innerClassSimpleName) {
         return signatureBuilder().signature(getCompiledSource().getDeclarations().stream()
+                .filter(FirRegularClass.class::isInstance)
                 .map(FirRegularClass.class::cast)
                 .flatMap(it -> it.getDeclarations().stream())
                 .filter(FirRegularClass.class::isInstance)
@@ -86,6 +88,7 @@ public class KotlinTypeSignatureBuilderTest {
 
     public String fieldSignature(String field) {
         return signatureBuilder().variableSignature(getCompiledSource().getDeclarations().stream()
+                .filter(FirRegularClass.class::isInstance)
                 .map(FirRegularClass.class::cast)
                 .flatMap(it -> it.getDeclarations().stream())
                 .filter(FirProperty.class::isInstance)
@@ -99,13 +102,14 @@ public class KotlinTypeSignatureBuilderTest {
     @Nullable
     public FirProperty getProperty(String field) {
         return getCompiledSource().getDeclarations().stream()
-          .map(FirRegularClass.class::cast)
-          .flatMap(it -> it.getDeclarations().stream())
-          .filter(FirProperty.class::isInstance)
-          .map(FirProperty.class::cast)
-          .filter(it -> field.equals(it.getName().asString()))
-          .findFirst()
-          .orElse(null);
+                .filter(FirRegularClass.class::isInstance)
+                .map(FirRegularClass.class::cast)
+                .flatMap(it -> it.getDeclarations().stream())
+                .filter(FirProperty.class::isInstance)
+                .map(FirProperty.class::cast)
+                .filter(it -> field.equals(it.getName().asString()))
+                .findFirst()
+                .orElse(null);
     }
 
     public String fieldPropertyGetterSignature(String field) {
@@ -126,6 +130,7 @@ public class KotlinTypeSignatureBuilderTest {
 
     public Object firstMethodParameterSignature(String methodName) {
         return signatureBuilder().signature(getCompiledSource().getDeclarations().stream()
+                .filter(FirRegularClass.class::isInstance)
                 .map(FirRegularClass.class::cast)
                 .flatMap(it -> it.getDeclarations().stream())
                 .filter(FirSimpleFunction.class::isInstance)
@@ -140,6 +145,7 @@ public class KotlinTypeSignatureBuilderTest {
 
     public Object lastClassTypeParameter() {
         return signatureBuilder().signature(getCompiledSource().getDeclarations().stream()
+                .filter(FirRegularClass.class::isInstance)
                 .map(FirRegularClass.class::cast)
                 .findFirst()
                 .orElseThrow()
@@ -149,6 +155,7 @@ public class KotlinTypeSignatureBuilderTest {
 
     public String methodSignature(String methodName) {
         return signatureBuilder().methodDeclarationSignature(getCompiledSource().getDeclarations().stream()
+                .filter(FirRegularClass.class::isInstance)
                 .map(FirRegularClass.class::cast)
                 .flatMap(it -> it.getDeclarations().stream())
                 .filter(FirSimpleFunction.class::isInstance)

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
@@ -160,6 +160,24 @@ public class KotlinTypeSignatureBuilderTest {
     }
 
     @Test
+    void fileField() {
+        FirProperty firProperty = getCompiledSource().getDeclarations().stream()
+          .filter(it -> it instanceof FirProperty && "field".equals(((FirProperty) it).getName().asString()))
+          .map(it -> (FirProperty) it).findFirst().orElseThrow();
+        assertThat(signatureBuilder().variableSignature(firProperty.getSymbol(), getCompiledSource().getSymbol()))
+          .isEqualTo("KotlinTypeGoatKt{name=field,type=kotlin.Int}");
+    }
+
+    @Test
+    void fileFunction() {
+        FirSimpleFunction function = getCompiledSource().getDeclarations().stream()
+          .filter(it -> it instanceof FirSimpleFunction && "function".equals(((FirSimpleFunction) it).getName().asString()))
+          .map(it -> (FirSimpleFunction) it).findFirst().orElseThrow();
+        assertThat(signatureBuilder().methodDeclarationSignature(function.getSymbol(), getCompiledSource().getSymbol()))
+          .isEqualTo("KotlinTypeGoatKt{name=function,return=kotlin.Unit,parameters=[]}");
+    }
+
+    @Test
     void constructor() {
         assertThat(constructorSignature())
                 .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=<constructor>,return=org.openrewrite.kotlin.KotlinTypeGoat,parameters=[]}");

--- a/src/test/resources/KotlinTypeGoat.kt
+++ b/src/test/resources/KotlinTypeGoat.kt
@@ -20,7 +20,9 @@ package org.openrewrite.kotlin
 
 import java.lang.Object
 
-// TODO: FIX ME. Files needs to declare fields and methods to assert type mapping.
+const val field = 10
+fun function() {}
+
 @AnnotationWithRuntimeRetention
 @AnnotationWithSourceRetention
 abstract class KotlinTypeGoat<T, S> where S: PT<S>, S: C {


### PR DESCRIPTION
Changes:
- Fixed owner type of top-level properties.
- Added signature builder and type mapping tests for top-level declarations.
- Updated type mapping test to set Parser.Input path.