### PR TITLE
Fixed various type issues

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -789,7 +789,9 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession) : Java
             if ((functionCall.calleeReference as FirResolvedNamedReference).resolvedSymbol is FirNamedFunctionSymbol) {
                 val resolvedSymbol =
                     (functionCall.calleeReference as FirResolvedNamedReference).resolvedSymbol as FirNamedFunctionSymbol
-                if (resolvedSymbol.containingClassLookupTag() != null) {
+                if (resolvedSymbol.dispatchReceiverType is ConeClassLikeType) {
+                    resolvedDeclaringType = TypeUtils.asFullyQualified(type(resolvedSymbol.dispatchReceiverType))
+                } else if (resolvedSymbol.containingClassLookupTag() != null) {
                     val lookupTag: ConeClassLikeLookupTag = resolvedSymbol.containingClassLookupTag()!!
                     val classSymbol: FirRegularClassSymbol? = lookupTag.toFirRegularClassSymbol(firSession)
                     if (classSymbol != null) {

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -604,6 +604,8 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession) : JavaTypeS
         var owner = "{undefined}"
         if (functionCall.explicitReceiver != null) {
             owner = signature(functionCall.explicitReceiver!!.typeRef)
+        } else if ((functionCall.calleeReference as FirResolvedNamedReference).resolvedSymbol is FirConstructorSymbol) {
+            return signature((functionCall.calleeReference as FirResolvedNamedReference).resolvedSymbol as FirConstructorSymbol)
         } else if (functionCall.calleeReference is FirResolvedNamedReference) {
             if ((functionCall.calleeReference as FirResolvedNamedReference).resolvedSymbol is FirNamedFunctionSymbol) {
                 val resolvedSymbol =


### PR DESCRIPTION
Changes:
- Declaring types of function calls with generic type parameters will contain the appropriate bounded types.
- The name of a destruct declaration initializer will contain the type rather than null.
- Anonymous objects with delegate constructors will contain the method type.