### PR TITLE
top-level function declaration type fixes.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
@@ -21,7 +21,7 @@ package org.openrewrite.kotlin
 import java.lang.Object
 
 const val field = 10
-fun function() {}
+fun function(arg: C) {}
 
 @AnnotationWithRuntimeRetention
 @AnnotationWithSourceRetention

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -1020,6 +1020,9 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession, firFil
                     "*"
                 }
 
+                is ConeIntersectionType -> {
+                    ""
+                }
                 else -> {
                     type.toString()
                 }

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -1005,7 +1005,9 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession, firFil
         val isGeneric = type is ConeKotlinTypeProjectionIn ||
                 type is ConeKotlinTypeProjectionOut ||
                 type is ConeStarProjection ||
-                type is ConeTypeParameterType
+                type is ConeTypeParameterType ||
+                type is ConeIntersectionType ||
+                type is ConeCapturedType
         if (isGeneric) {
             var variance: JavaType.GenericTypeVariable.Variance = JavaType.GenericTypeVariable.Variance.INVARIANT
             var bounds: MutableList<JavaType>? = null
@@ -1014,7 +1016,7 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession, firFil
                     "?"
                 }
 
-                is ConeStarProjection -> {
+                is ConeStarProjection, is ConeCapturedType -> {
                     "*"
                 }
 
@@ -1054,6 +1056,11 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession, firFil
                             bounds.add(type(bound))
                         }
                     }
+                }
+            } else if (type is ConeIntersectionType) {
+                bounds = ArrayList(type.intersectedTypes.size)
+                for (t: ConeTypeProjection in type.intersectedTypes) {
+                    bounds.add(type(t))
                 }
             }
             gtv.unsafeSet(name, variance, bounds)

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -1011,7 +1011,7 @@ class KotlinTypeMapping(typeCache: JavaTypeCache, firSession: FirSession, firFil
             var bounds: MutableList<JavaType>? = null
             val name: String = when (type) {
                 is ConeKotlinTypeProjectionIn, is ConeKotlinTypeProjectionOut -> {
-                    ""
+                    "?"
                 }
 
                 is ConeStarProjection -> {

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -37,7 +37,6 @@ import org.jetbrains.kotlin.fir.expressions.impl.FirSingleExpressionBlock
 import org.jetbrains.kotlin.fir.expressions.impl.FirUnitExpression
 import org.jetbrains.kotlin.fir.references.*
 import org.jetbrains.kotlin.fir.resolve.toFirRegularClassSymbol
-import org.jetbrains.kotlin.fir.resolve.toSymbol
 import org.jetbrains.kotlin.fir.symbols.ConeClassLikeLookupTag
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -123,7 +122,7 @@ class KotlinParserVisitor(
         charset = `is`.charset
         charsetBomMarked = `is`.isCharsetBomMarked
         this.styles = styles
-        typeMapping = KotlinTypeMapping(typeCache, firSession)
+        typeMapping = KotlinTypeMapping(typeCache, firSession, kotlinSource.firFile!!.symbol)
         this.data = data
         this.firSession = firSession
         this.nodes = kotlinSource.nodes

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -383,7 +383,7 @@ public class KotlinTypeMappingTest {
                         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean atomicBoolean) {
                             if (methodMatcher.matches(method)) {
                                 assertThat(method.getMethodType().toString())
-                                  .isEqualTo("kotlin.collections.CollectionsKt{name=listOf,return=kotlin.collections.List<kotlin.Pair<kotlin.String, Generic{it(kotlin/Comparable<*> & java/io/Serializable)kotlin.Comparable<Generic{*}> & java.io.Serializable}>>,parameters=[kotlin.Array<Generic{? extends Generic{T}}>]}");
+                                  .isEqualTo("kotlin.collections.CollectionsKt{name=listOf,return=kotlin.collections.List<kotlin.Pair<kotlin.String, Generic{kotlin.Comparable<Generic{*}> & java.io.Serializable}>>,parameters=[kotlin.Array<Generic{? extends Generic{T}}>]}");
                                 found.set(true);
                             }
                             return super.visitMethodInvocation(method, atomicBoolean);

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.kotlin;
 
-import org.jetbrains.kotlin.fir.declarations.FirProperty;
-import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
@@ -157,7 +155,13 @@ public class KotlinTypeMappingTest {
 
         assertThat(md.getName().getType()).isEqualTo(md.getMethodType());
         assertThat(md.getMethodType().toString())
-          .isEqualTo("KotlinTypeGoatKt{name=function,return=kotlin.Unit,parameters=[]}");
+          .isEqualTo("KotlinTypeGoatKt{name=function,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.C]}");
+
+        J.VariableDeclarations.NamedVariable nv = ((J.VariableDeclarations) md.getParameters().get(0)).getVariables().get(0);
+        assertThat(nv.getVariableType()).isEqualTo(nv.getName().getFieldType());
+        assertThat(nv.getType().toString()).isEqualTo("org.openrewrite.kotlin.C");
+        assertThat(nv.getVariableType().toString())
+          .isEqualTo("KotlinTypeGoatKt{name=function,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.C]}{name=arg,type=org.openrewrite.kotlin.C}");
     }
 
     @Test

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -205,7 +205,7 @@ public class KotlinTypeMappingTest {
     @Test
     void generic() {
         JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) TypeUtils.asParameterized(firstMethodParameter("generic")).getTypeParameters().get(0);
-        assertThat(generic.getName()).isEqualTo("");
+        assertThat(generic.getName()).isEqualTo("?");
         assertThat(generic.getVariance()).isEqualTo(COVARIANT);
         assertThat(TypeUtils.asFullyQualified(generic.getBounds().get(0)).getFullyQualifiedName()).isEqualTo("org.openrewrite.kotlin.C");
     }
@@ -213,7 +213,7 @@ public class KotlinTypeMappingTest {
     @Test
     void genericContravariant() {
         JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) TypeUtils.asParameterized(firstMethodParameter("genericContravariant")).getTypeParameters().get(0);
-        assertThat(generic.getName()).isEqualTo("");
+        assertThat(generic.getName()).isEqualTo("?");
         assertThat(generic.getVariance()).isEqualTo(CONTRAVARIANT);
         assertThat(TypeUtils.asFullyQualified(generic.getBounds().get(0)).getFullyQualifiedName()).
           isEqualTo("org.openrewrite.kotlin.C");
@@ -243,7 +243,7 @@ public class KotlinTypeMappingTest {
         JavaType.Parameterized param = (JavaType.Parameterized) firstMethodParameter("genericRecursive");
         JavaType typeParam = param.getTypeParameters().get(0);
         JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) typeParam;
-        assertThat(generic.getName()).isEqualTo("");
+        assertThat(generic.getName()).isEqualTo("?");
         assertThat(generic.getVariance()).isEqualTo(COVARIANT);
         assertThat(TypeUtils.asParameterized(generic.getBounds().get(0))).isNotNull();
 

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
@@ -52,7 +52,7 @@ public class KotlinTypeSignatureBuilderTest {
     }
 
     public KotlinTypeSignatureBuilder signatureBuilder() {
-        return new KotlinTypeSignatureBuilder(compiledSource.getFirSession());
+        return new KotlinTypeSignatureBuilder(compiledSource.getFirSession(), compiledSource.getSources().iterator().next().getFirFile().getSymbol());
     }
 
     private FirFile getCompiledSource() {
@@ -181,7 +181,7 @@ public class KotlinTypeSignatureBuilderTest {
           .filter(it -> it instanceof FirSimpleFunction && "function".equals(((FirSimpleFunction) it).getName().asString()))
           .map(it -> (FirSimpleFunction) it).findFirst().orElseThrow();
         assertThat(signatureBuilder().methodDeclarationSignature(function.getSymbol(), getCompiledSource().getSymbol()))
-          .isEqualTo("KotlinTypeGoatKt{name=function,return=kotlin.Unit,parameters=[]}");
+          .isEqualTo("KotlinTypeGoatKt{name=function,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.C]}");
     }
 
     @Test

--- a/src/test/resources/KotlinTypeGoat.kt
+++ b/src/test/resources/KotlinTypeGoat.kt
@@ -21,7 +21,7 @@ package org.openrewrite.kotlin
 import java.lang.Object
 
 const val field = 10
-fun function() {}
+fun function(arg: C) {}
 
 @AnnotationWithRuntimeRetention
 @AnnotationWithSourceRetention


### PR DESCRIPTION
Changes:
- Function signature and types will contain the correct type from a ConeClassLikeType instead of JavaType.Unknown.
- Added FirFileSymbol as field to SignatureBuilder and TypeMapping to cover top-level declarations.
- Fixed signature and type for the owner of JavaType$Variable from top-level method declaration method parameters.
- Kotlin generic bounds in and out {type} will contain the equivalent java name `?`
- ConeIntersectionType will return a generic with the correct bounds instead of JavaType.Unknown.