### PR TITLE
Fix generic type name of ConeIntersectionTypes.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -330,7 +330,7 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
             }
         }
         val boundSigStr = boundSigs.toString()
-        if (!boundSigStr.isEmpty()) {
+        if (boundSigStr.isNotEmpty()) {
             s.append(" extends ").append(boundSigStr)
         }
         typeVariableNameStack!!.remove(name)
@@ -344,12 +344,12 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
         val s = StringBuilder()
         if (type is ConeKotlinTypeProjectionIn) {
             val (type1) = type
-            s.append("Generic{in ")
+            s.append("Generic{? super ")
             s.append(signature(type1))
             s.append("}")
         } else if (type is ConeKotlinTypeProjectionOut) {
             val (type1) = type
-            s.append("Generic{out ")
+            s.append("Generic{? extends ")
             s.append(signature(type1))
             s.append("}")
         } else if (type is ConeStarProjection) {

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
@@ -241,9 +241,9 @@ public class KotlinTypeSignatureBuilderTest {
     @Test
     void generic() {
         assertThat(firstMethodParameterSignature("generic"))
-                .isEqualTo("org.openrewrite.kotlin.PT<Generic{out org.openrewrite.kotlin.C}>");
+                .isEqualTo("org.openrewrite.kotlin.PT<Generic{? extends org.openrewrite.kotlin.C}>");
         assertThat(methodSignature("generic"))
-                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=generic,return=org.openrewrite.kotlin.PT<Generic{out org.openrewrite.kotlin.C}>,parameters=[org.openrewrite.kotlin.PT<Generic{out org.openrewrite.kotlin.C}>]}");
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=generic,return=org.openrewrite.kotlin.PT<Generic{? extends org.openrewrite.kotlin.C}>,parameters=[org.openrewrite.kotlin.PT<Generic{? extends org.openrewrite.kotlin.C}>]}");
     }
 
     @Test
@@ -257,9 +257,9 @@ public class KotlinTypeSignatureBuilderTest {
     @Test
     void genericContravariant() {
         assertThat(firstMethodParameterSignature("genericContravariant"))
-                .isEqualTo("org.openrewrite.kotlin.PT<Generic{in org.openrewrite.kotlin.C}>");
+                .isEqualTo("org.openrewrite.kotlin.PT<Generic{? super org.openrewrite.kotlin.C}>");
         assertThat(methodSignature("genericContravariant"))
-                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericContravariant,return=org.openrewrite.kotlin.PT<Generic{in org.openrewrite.kotlin.C}>,parameters=[org.openrewrite.kotlin.PT<Generic{in org.openrewrite.kotlin.C}>]}");
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericContravariant,return=org.openrewrite.kotlin.PT<Generic{? super org.openrewrite.kotlin.C}>,parameters=[org.openrewrite.kotlin.PT<Generic{? super org.openrewrite.kotlin.C}>]}");
     }
 
     @Test
@@ -318,9 +318,9 @@ public class KotlinTypeSignatureBuilderTest {
     @Test
     void genericRecursiveInMethodDeclaration() {
         assertThat(firstMethodParameterSignature("genericRecursive"))
-                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat<Generic{out kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>");
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat<Generic{? extends kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>");
         assertThat(methodSignature("genericRecursive"))
-                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericRecursive,return=org.openrewrite.kotlin.KotlinTypeGoat<Generic{out kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>,parameters=[org.openrewrite.kotlin.KotlinTypeGoat<Generic{out kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>]}");
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericRecursive,return=org.openrewrite.kotlin.KotlinTypeGoat<Generic{? extends kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>,parameters=[org.openrewrite.kotlin.KotlinTypeGoat<Generic{? extends kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>]}");
     }
 
     @Test


### PR DESCRIPTION
Changes:

- Updated GTV covariant and contravariant signatures to match JavaSignatureBuilder.
- Moved ConeTypeProjection types: ConeClassLikeType and ConeFlexibleType from resolve ConeTypeProjection up to type(...).