### PR TITLE
Fixed clazz type on ParameterizedTypes created through UserTypeRefs.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -2478,7 +2478,7 @@ class KotlinParserVisitor(
             if (j is J.ParameterizedType) {
                 // The identifier on a parameterized type of the FIR does not contain type information and must be added separately.
                 val parameterizedType = j
-                j = parameterizedType.withClazz(parameterizedType.clazz.withType(type))
+                j = parameterizedType.withClazz(parameterizedType.clazz.withType(if (type is JavaType.Parameterized) type.type else type))
             }
             return j!!
         } else {

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -200,6 +200,17 @@ public class KotlinTypeMappingTest {
         JavaType.Parameterized parameterized = (JavaType.Parameterized) firstMethodParameter("parameterized");
         assertThat(parameterized.getType().getFullyQualifiedName()).isEqualTo("org.openrewrite.kotlin.PT");
         assertThat(TypeUtils.asFullyQualified(parameterized.getTypeParameters().get(0)).getFullyQualifiedName()).isEqualTo("org.openrewrite.kotlin.C");
+
+        J.MethodDeclaration md = goatClassDeclaration.getClassDeclaration().getBody().getStatements().stream()
+          .filter(it -> (it instanceof J.MethodDeclaration) && "parameterized".equals(((J.MethodDeclaration) it).getSimpleName()))
+          .map(J.MethodDeclaration.class::cast).findFirst().orElseThrow();
+        assertThat(md.getMethodType().toString())
+          .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=parameterized,return=org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>,parameters=[org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>]}");
+        J.VariableDeclarations vd = ((J.VariableDeclarations) md.getParameters().get(0));
+        assertThat(vd.getTypeExpression().getType().toString())
+          .isEqualTo("org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>");
+        assertThat(((J.ParameterizedType) vd.getTypeExpression()).getClazz().getType().toString())
+          .isEqualTo("org.openrewrite.kotlin.PT");
     }
 
     @Test


### PR DESCRIPTION
Change:

- `J.ParameterizedType` created from `UserTypeRef` will contain the `JavaType$Class` rather than the `JavaType$Parameterized`