### PR TITLE
Present bit operators to J.Binary instead of method invocation

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -495,22 +495,22 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                     keyword = "!=";
                     break;
                 case BitAnd:
-                    keyword = "&";
+                    keyword = "and";
                     break;
                 case BitOr:
-                    keyword = "|";
+                    keyword = "or";
                     break;
                 case BitXor:
-                    keyword = "^";
+                    keyword = "xor";
                     break;
                 case LeftShift:
-                    keyword = "<<";
+                    keyword = "shl";
                     break;
                 case RightShift:
-                    keyword = ">>";
+                    keyword = "shr";
                     break;
                 case UnsignedRightShift:
-                    keyword = ">>>";
+                    keyword = "ushr";
                     break;
                 case Or:
                     keyword = (binary.getMarkers().findFirst(LogicalComma.class).isPresent()) ? "," : "||";

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2839,6 +2839,23 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     private J.Binary.Type mapJBinaryType(KtOperationReferenceExpression operationReference) {
         IElementType elementType = operationReference.getOperationSignTokenType();
 
+        if (elementType == null) {
+            String operator = operationReference.getText();
+            if ("and".equals(operator)) {
+                return J.Binary.Type.BitAnd;
+            } else if ("or".equals(operator)) {
+                return J.Binary.Type.BitOr;
+            } else if ("xor".equals(operator)) {
+                return J.Binary.Type.BitXor;
+            } else if ("shl".equals(operator)) {
+                return J.Binary.Type.LeftShift;
+            } else if ("shr".equals(operator)) {
+                return J.Binary.Type.RightShift;
+            } else if ("ushr".equals(operator)) {
+                return J.Binary.Type.UnsignedRightShift;
+            }
+        }
+
         if (elementType == KtTokens.PLUS)
             return J.Binary.Type.Addition;
         else if (elementType == KtTokens.MINUS)


### PR DESCRIPTION
For `!in` binary operator we no longer present it as a method invocation but as a `K.Binary` with `NotContains` type.

Similarly, For bit operators like bit and/or/xor, we should map them to a J.Binary instead of method invocations.
