### PR TITLE
IR type mapping and signature building

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -58,7 +58,6 @@ import org.jetbrains.kotlin.fir.session.FirSessionFactoryHelper;
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope;
 import org.jetbrains.kotlin.idea.KotlinFileType;
 import org.jetbrains.kotlin.idea.KotlinLanguage;
-import org.jetbrains.kotlin.ir.declarations.IrFile;
 import org.jetbrains.kotlin.load.kotlin.PackagePartProvider;
 import org.jetbrains.kotlin.modules.Module;
 import org.jetbrains.kotlin.name.Name;

--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -58,7 +58,6 @@ import org.jetbrains.kotlin.fir.session.FirSessionFactoryHelper;
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope;
 import org.jetbrains.kotlin.idea.KotlinFileType;
 import org.jetbrains.kotlin.idea.KotlinLanguage;
-import org.jetbrains.kotlin.ir.declarations.IrClass;
 import org.jetbrains.kotlin.ir.declarations.IrFile;
 import org.jetbrains.kotlin.load.kotlin.PackagePartProvider;
 import org.jetbrains.kotlin.modules.Module;

--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -518,7 +518,8 @@ public class KotlinParser implements Parser {
         List<IrFile> files = actualizedResult.getIrModuleFragment().getFiles();
         for (int i = 0; i < files.size(); i++) {
             kotlinSources.get(i).setFirFile(second.get(i));
-            kotlinSources.get(i).setIrFile(files.get(i));
+//            kotlinSources.get(i).setIrFile(files.get(i));
+//            new KotlinIrTypeMapping(new JavaTypeCache()).type(files.get(i));
         }
 
         return new CompiledSource(firSession, kotlinSources);

--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -22,6 +22,7 @@ import kotlin.jvm.functions.Function1;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.intellij.lang.annotations.Language;
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension;
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments;
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector;
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector;
@@ -32,16 +33,22 @@ import org.jetbrains.kotlin.cli.jvm.config.JvmContentRootsKt;
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable;
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer;
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt;
+import org.jetbrains.kotlin.com.intellij.openapi.vfs.StandardFileSystems;
 import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.kotlin.com.intellij.openapi.vfs.VirtualFileManager;
 import org.jetbrains.kotlin.com.intellij.psi.FileViewProvider;
 import org.jetbrains.kotlin.com.intellij.psi.PsiManager;
 import org.jetbrains.kotlin.com.intellij.psi.SingleRootFileViewProvider;
+import org.jetbrains.kotlin.com.intellij.psi.search.GlobalSearchScope;
 import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile;
 import org.jetbrains.kotlin.config.*;
+import org.jetbrains.kotlin.constant.EvaluatedConstTracker;
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporterFactory;
 import org.jetbrains.kotlin.diagnostics.impl.BaseDiagnosticsCollector;
 import org.jetbrains.kotlin.fir.DependencyListForCliModule;
 import org.jetbrains.kotlin.fir.FirSession;
+import org.jetbrains.kotlin.fir.backend.Fir2IrConfiguration;
+import org.jetbrains.kotlin.fir.backend.Fir2IrExtensions;
 import org.jetbrains.kotlin.fir.declarations.FirFile;
 import org.jetbrains.kotlin.fir.java.FirProjectSessionProvider;
 import org.jetbrains.kotlin.fir.pipeline.*;
@@ -51,6 +58,10 @@ import org.jetbrains.kotlin.fir.session.FirSessionFactoryHelper;
 import org.jetbrains.kotlin.fir.session.environment.AbstractProjectFileSearchScope;
 import org.jetbrains.kotlin.idea.KotlinFileType;
 import org.jetbrains.kotlin.idea.KotlinLanguage;
+import org.jetbrains.kotlin.ir.declarations.IrClass;
+import org.jetbrains.kotlin.ir.declarations.IrFile;
+import org.jetbrains.kotlin.load.kotlin.PackagePartProvider;
+import org.jetbrains.kotlin.modules.Module;
 import org.jetbrains.kotlin.name.Name;
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms;
 import org.jetbrains.kotlin.psi.KtFile;
@@ -81,14 +92,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.jetbrains.kotlin.cli.common.CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY;
 import static org.jetbrains.kotlin.cli.common.messages.MessageRenderer.PLAIN_FULL_PATHS;
 import static org.jetbrains.kotlin.cli.jvm.JvmArgumentsKt.*;
-import static org.jetbrains.kotlin.cli.jvm.compiler.pipeline.CompilerPipelineKt.createProjectEnvironment;
+import static org.jetbrains.kotlin.cli.jvm.K2JVMCompilerKt.configureModuleChunk;
 import static org.jetbrains.kotlin.cli.jvm.config.JvmContentRootsKt.*;
 import static org.jetbrains.kotlin.config.CommonConfigurationKeys.*;
 import static org.jetbrains.kotlin.config.JVMConfigurationKeys.DO_NOT_CLEAR_BINDING_CONTEXT;
+import static org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualizeForJvm;
 import static org.jetbrains.kotlin.incremental.IncrementalFirJvmCompilerRunnerKt.configureBaseRoots;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -368,7 +381,6 @@ public class KotlinParser implements Parser {
 
     public CompiledSource parse(List<Parser.Input> sources, Disposable disposable, ExecutionContext ctx) {
         CompilerConfiguration compilerConfiguration = compilerConfiguration();
-
         if (classpath != null) {
             for (Path path : classpath) {
                 File file;
@@ -390,6 +402,8 @@ public class KotlinParser implements Parser {
         configureContentRootsFromClassPath(compilerConfiguration, arguments);
         configureJdkClasspathRoots(compilerConfiguration);
         configureBaseRoots(compilerConfiguration, arguments);
+
+        Module module = configureModuleChunk(compilerConfiguration, arguments, null).getModules().get(0);
 
         KotlinCoreEnvironment environment = KotlinCoreEnvironment.createForProduction(
                 disposable,
@@ -423,8 +437,12 @@ public class KotlinParser implements Parser {
         }
 
         BaseDiagnosticsCollector diagnosticsReporter = DiagnosticReporterFactory.INSTANCE.createReporter(false);
-        VfsBasedProjectEnvironment projectEnvironment = createProjectEnvironment(compilerConfiguration, disposable,
-                EnvironmentConfigFiles.JVM_CONFIG_FILES, compilerConfiguration.getNotNull(MESSAGE_COLLECTOR_KEY));
+        Function1<? super GlobalSearchScope, PackagePartProvider> providerFunction1 = environment::createPackagePartProvider;
+        VfsBasedProjectEnvironment projectEnvironment = new VfsBasedProjectEnvironment(
+                environment.getProject(),
+                VirtualFileManager.getInstance().getFileSystem(StandardFileSystems.FILE_PROTOCOL),
+                providerFunction1);
+
         AbstractProjectFileSearchScope sourceScope = projectEnvironment.getSearchScopeByPsiFiles(ktFiles, false);
         sourceScope.plus(projectEnvironment.getSearchScopeForProjectJavaSources());
 
@@ -453,7 +471,7 @@ public class KotlinParser implements Parser {
         Function1<FirSessionConfigurator, Unit> sessionConfigurator = session -> Unit.INSTANCE;
 
         FirSession firSession = FirSessionFactoryHelper.INSTANCE.createSessionWithDependencies(
-                Name.identifier(moduleName),
+                Name.identifier(module.getModuleName()),
                 JvmPlatforms.INSTANCE.getUnspecifiedJvmPlatform(),
                 JvmPlatformAnalyzerServices.INSTANCE,
                 sessionProvider,
@@ -473,23 +491,35 @@ public class KotlinParser implements Parser {
         List<FirFile> rawFir = FirUtilsKt.buildFirFromKtFiles(firSession, ktFiles);
         Pair<ScopeSession, List<FirFile>> result = AnalyseKt.runResolution(firSession, rawFir);
         AnalyseKt.runCheckers(firSession, result.getFirst(), result.getSecond(), diagnosticsReporter);
-//        ModuleCompilerAnalyzedOutput analyzedOutput = new ModuleCompilerAnalyzedOutput(firSession, result.getFirst(), result.getSecond());
-//        FirResult firResult = new FirResult(singletonList(analyzedOutput));
-//
-//        Fir2IrExtensions extensions = Fir2IrExtensions.Default.INSTANCE;
-//        Fir2IrConfiguration irConfiguration = new Fir2IrConfiguration(
-//                languageVersionSettings,
-//                compilerConfiguration.getBoolean(JVMConfigurationKeys.LINK_VIA_SIGNATURES),
-//                compilerConfiguration.putIfAbsent(EVALUATED_CONST_TRACKER, EvaluatedConstTracker.Companion.create())
-//        );
-//        // TODO: add generation extensions
-//        List<IrGenerationExtension> irGenerationExtensions = new ArrayList<>();
-//        Fir2IrActualizedResult actualizedResult = convertToIrAndActualizeForJvm(firResult, extensions, irConfiguration, irGenerationExtensions, diagnosticsReporter);
+        ModuleCompilerAnalyzedOutput analyzedOutput = new ModuleCompilerAnalyzedOutput(firSession, result.getFirst(), result.getSecond());
+        FirResult firResult = new FirResult(singletonList(analyzedOutput));
 
-        assert kotlinSources.size() == result.getSecond().size();
+        Fir2IrExtensions extensions = Fir2IrExtensions.Default.INSTANCE;
+        Fir2IrConfiguration irConfiguration = new Fir2IrConfiguration(
+                languageVersionSettings,
+                compilerConfiguration.getBoolean(JVMConfigurationKeys.LINK_VIA_SIGNATURES),
+                compilerConfiguration.putIfAbsent(EVALUATED_CONST_TRACKER, EvaluatedConstTracker.Companion.create())
+        );
+
+        List<IrGenerationExtension> irGenerationExtensions = IrGenerationExtension.Companion.getInstances(projectEnvironment.getProject());
+        Fir2IrActualizedResult actualizedResult;
+        try {
+            actualizedResult = convertToIrAndActualizeForJvm(firResult, extensions, irConfiguration, irGenerationExtensions, diagnosticsReporter);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         List<FirFile> second = result.getSecond();
         for (int i = 0; i < second.size(); i++) {
             kotlinSources.get(i).setFirFile(second.get(i));
+        }
+
+        assert kotlinSources.size() == result.getSecond().size();
+        assert kotlinSources.size() == actualizedResult.getIrModuleFragment().getFiles().size();
+        List<IrFile> files = actualizedResult.getIrModuleFragment().getFiles();
+        for (int i = 0; i < files.size(); i++) {
+            kotlinSources.get(i).setFirFile(second.get(i));
+            kotlinSources.get(i).setIrFile(files.get(i));
         }
 
         return new CompiledSource(firSession, kotlinSources);

--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -509,9 +509,6 @@ public class KotlinParser implements Parser {
         }
 
         List<FirFile> second = result.getSecond();
-        for (int i = 0; i < second.size(); i++) {
-            kotlinSources.get(i).setFirFile(second.get(i));
-        }
 
         assert kotlinSources.size() == result.getSecond().size();
         assert kotlinSources.size() == actualizedResult.getIrModuleFragment().getFiles().size();

--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -518,7 +518,7 @@ public class KotlinParser implements Parser {
         List<IrFile> files = actualizedResult.getIrModuleFragment().getFiles();
         for (int i = 0; i < files.size(); i++) {
             kotlinSources.get(i).setFirFile(second.get(i));
-//            kotlinSources.get(i).setIrFile(files.get(i));
+            kotlinSources.get(i).setIrFile(files.get(i));
 //            new KotlinIrTypeMapping(new JavaTypeCache()).type(files.get(i));
         }
 

--- a/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
+++ b/src/main/java/org/openrewrite/kotlin/KotlinTypeGoat.kt
@@ -72,10 +72,9 @@ abstract class KotlinTypeGoat<T, S> where S: PT<S>, S: C {
     abstract fun <U> inheritedKotlinTypeGoat(n: InheritedKotlinTypeGoat<T, U>): InheritedKotlinTypeGoat<T, U> where U : PT<U>, U : C
     abstract fun <U> genericIntersection(n: U): U where U : TypeA, U : PT<U>, U : C
     abstract fun genericT(n: T): T // remove after signatures are common.
-
     abstract fun <U> recursiveIntersection(n: U) where U : Extension<U>, U : Intersection<U>
-
     abstract fun javaType(n: Object)
+    abstract fun TypeA.receiver(n: C)
 }
 
 interface C {

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinIrTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinIrTypeMapping.kt
@@ -1,0 +1,334 @@
+package org.openrewrite.kotlin
+
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.DescriptorVisibility
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.fir.lazy.Fir2IrLazyClass
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.properties
+import org.openrewrite.java.JavaTypeMapping
+import org.openrewrite.java.internal.JavaTypeCache
+import org.openrewrite.java.tree.JavaType
+import org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.COVARIANT
+import org.openrewrite.java.tree.JavaType.GenericTypeVariable.Variance.INVARIANT
+import org.openrewrite.java.tree.TypeUtils
+
+class KotlinIrTypeMapping(typeCache: JavaTypeCache): JavaTypeMapping<Any> {
+    private val signatureBuilder: KotlinTypeIrSignatureBuilder = KotlinTypeIrSignatureBuilder()
+    private val typeCache: JavaTypeCache
+
+    init {
+        this.typeCache = typeCache
+    }
+
+    // TODO: temp to map types without parser visitor.
+    fun type(irFile: IrFile) {
+        for (ann in irFile.annotations) {
+            type(ann)
+        }
+        for (dec in irFile.declarations) {
+            type(dec)
+        }
+    }
+
+    override fun type(type: Any?): JavaType {
+        if (type == null || type is IrErrorType) {
+            return JavaType.Unknown.getInstance()
+        }
+
+        if (type is IrSimpleType) {
+            return type(type.classifier)
+        }
+
+        if (type is IrClassifierSymbol) {
+            return type(type.owner)
+        }
+
+        val signature = signatureBuilder.signature(type)
+        val existing: JavaType? = typeCache.get(signature)
+        if (existing != null) {
+            return existing
+        }
+
+        when (type) {
+            is IrFile -> {
+                return fileType(signature)
+            }
+            is IrClass -> {
+               return classType(type, signature)
+            }
+
+            is IrFunction -> {
+                return methodDeclarationType(type)
+            }
+
+            is IrProperty -> {
+                return variableType(type)
+            }
+
+            is IrVariable -> {
+                TODO("IrVariable not implemented")
+            }
+
+            is IrField -> {
+                TODO("IrField not implemented")
+            }
+
+            is IrTypeParameter -> {
+               return generic(type, signature)
+            }
+        }
+
+        throw UnsupportedOperationException("Unsupported type: ${type.javaClass}")
+    }
+
+    private fun fileType(signature: String): JavaType {
+        val existing = typeCache.get<JavaType.FullyQualified>(signature)
+        if (existing != null) {
+            return existing
+        }
+        val fileType = JavaType.ShallowClass.build(signature)
+        typeCache.put(signature, fileType)
+        return fileType
+    }
+
+    private fun classType(irClass: IrClass, signature: String): JavaType {
+        val fqn: String = signatureBuilder.classSignature(irClass)
+        val fq: JavaType.FullyQualified? = typeCache.get(fqn)
+        var clazz: JavaType.Class? = (if (fq is JavaType.Parameterized) fq.type else fq) as JavaType.Class?
+        if (clazz == null) {
+            clazz = JavaType.Class(
+                null,
+                mapToFlagsBitmap(irClass.visibility, irClass.modality),
+                fqn,
+                mapKind(irClass.kind),
+                null, null, null, null, null, null, null
+            )
+
+            typeCache.put(fqn, clazz)
+
+            var supertype: JavaType.FullyQualified? = null
+            var interfaceSymbols: MutableList<IrSymbolOwner>? = null
+            for (sType in irClass.superTypes) {
+                when (val classifier: IrClassifierSymbol? = sType.classifierOrNull) {
+                    is IrClassSymbol -> {
+                        when (classifier.owner.kind) {
+                            ClassKind.CLASS -> {
+                                supertype = TypeUtils.asFullyQualified(type(classifier.owner))
+                            }
+                            ClassKind.INTERFACE -> {
+                                if (interfaceSymbols == null) {
+                                    interfaceSymbols = ArrayList()
+                                }
+                                interfaceSymbols.add(classifier.owner)
+                            }
+                            else -> {
+                                TODO()
+                            }
+                        }
+                    }
+                    else -> {
+                        TODO()
+                    }
+                }
+            }
+            var owner: JavaType.FullyQualified? = null
+            if (irClass.parent is IrClass) {
+                owner = TypeUtils.asFullyQualified(type(irClass.parent))
+            }
+            var fields: MutableList<JavaType.Variable>? = null
+            for (property: IrProperty in irClass.properties) {
+                if (fields == null) {
+                    fields = ArrayList(irClass.properties.toList().size)
+                }
+                val vt = variableType(property)
+                fields.add(vt)
+            }
+
+            var methods: MutableList<JavaType.Method>? = null
+            for (function: IrFunction in irClass.functions) {
+                if (methods == null) {
+                    methods = ArrayList(irClass.functions.toList().size)
+                }
+                val mt = methodDeclarationType(function)
+                methods.add(mt)
+            }
+
+            var interfaces: MutableList<JavaType.FullyQualified>? = null
+            if (!interfaceSymbols.isNullOrEmpty()) {
+                interfaces = ArrayList(interfaceSymbols.size)
+                for (interfaceSymbol: IrSymbolOwner in interfaceSymbols) {
+                    val sym: Any = if (interfaceSymbol is Fir2IrLazyClass) interfaceSymbol.symbol.owner.symbol else interfaceSymbol
+                    val javaType = TypeUtils.asFullyQualified(type(sym))
+                    if (javaType != null) {
+                        interfaces.add(javaType)
+                    }
+                }
+            }
+            clazz.unsafeSet(null, supertype, owner, listAnnotations(irClass.annotations), interfaces, fields, methods)
+        }
+
+        if (irClass.typeParameters.isNotEmpty()) {
+            var pt = typeCache.get<JavaType.Parameterized>(signature)
+            if (pt == null) {
+                pt = JavaType.Parameterized(null, null, null)
+                val typeParameters: MutableList<JavaType> = ArrayList(irClass.typeParameters.size)
+                for (typeParam: IrTypeParameter in irClass.typeParameters) {
+                    typeParameters.add(type(typeParam))
+                }
+                pt.unsafeSet(clazz, typeParameters)
+            }
+            return pt
+        }
+        return clazz
+    }
+
+    private fun generic(type: IrTypeParameter, signature: String): JavaType {
+        val name = type.name.asString()
+        val gtv: JavaType.GenericTypeVariable = JavaType.GenericTypeVariable(null, name, INVARIANT, null)
+        typeCache.put(signature, gtv)
+
+        var bounds: MutableList<JavaType>? = null
+        if (type.isReified) {
+            TODO()
+        }
+        for (bound: IrType in type.superTypes) {
+            if (isNotAny(bound)) {
+                if (bounds == null) {
+                    bounds = ArrayList()
+                }
+                bounds.add(type(bound))
+            }
+        }
+        gtv.unsafeSet(gtv.name, if (bounds == null) INVARIANT else COVARIANT, bounds)
+        return gtv
+    }
+
+    private fun methodDeclarationType(function: IrFunction): JavaType.Method {
+        val signature = signatureBuilder.methodDeclarationSignature(function)
+        val existing = typeCache.get<JavaType.Method>(signature)
+        if (existing != null) {
+            return existing
+        }
+
+        val paramNames: MutableList<String>? = if (function.valueParameters.isEmpty()) null else ArrayList(function.valueParameters.size)
+        for (param: IrValueParameter in function.valueParameters) {
+            paramNames!!.add(param.name.asString())
+        }
+        val method = JavaType.Method(
+            null,
+            mapToFlagsBitmap(function.visibility),
+            null,
+            if (function is IrConstructor) "<constructor>" else function.name.asString(),
+            null,
+            paramNames,
+            null, null, null, null
+        )
+        typeCache.put(signature, method)
+        val declaringType = TypeUtils.asFullyQualified(type(function.parent))
+        if (declaringType == null) {
+            TODO()
+        }
+        val returnType = type(function.returnType)
+        val paramTypes: MutableList<JavaType>? = if (function.valueParameters.isEmpty()) null else ArrayList(function.valueParameters.size)
+        for (param: IrValueParameter in function.valueParameters) {
+            paramTypes!!.add(type(param.type))
+        }
+        method.unsafeSet(
+            declaringType,
+            if (function is IrConstructor) declaringType else returnType,
+            paramTypes, null, listAnnotations(function.annotations)
+        )
+        return method
+    }
+
+    fun variableType(
+        property: IrProperty
+    ): JavaType.Variable {
+        val signature = signatureBuilder.variableSignature(property)
+        val existing = typeCache.get<JavaType.Variable>(signature)
+        if (existing != null) {
+            return existing
+        }
+        val variable = JavaType.Variable(
+            null,
+            0,
+            property.name.asString(),
+            null, null, null
+        )
+        typeCache.put(signature, variable)
+        val annotations = listAnnotations(property.annotations)
+        val owner = type(property.parent)
+        val typeRef = if (property.getter != null) {
+            type(property.getter!!.returnType)
+        } else if (property.backingField != null) {
+            type(property.backingField!!.type)
+        } else {
+            TODO()
+        }
+        variable.unsafeSet(owner, typeRef, annotations)
+        return variable
+    }
+
+    private fun listAnnotations(annotations: List<IrConstructorCall>): List<JavaType.FullyQualified> {
+        val mapped: MutableList<JavaType.FullyQualified> = ArrayList(annotations.size)
+        for (annotation: IrConstructorCall in annotations) {
+            val type = TypeUtils.asFullyQualified(type(annotation.type))
+            if (type != null) {
+                mapped.add(type)
+            }
+        }
+        return mapped.toList()
+    }
+
+    private fun mapKind(kind: ClassKind): JavaType.FullyQualified.Kind {
+        return when (kind) {
+            ClassKind.INTERFACE -> JavaType.FullyQualified.Kind.Interface
+            ClassKind.ENUM_CLASS -> JavaType.FullyQualified.Kind.Enum
+            ClassKind.ENUM_ENTRY -> TODO()
+            ClassKind.ANNOTATION_CLASS -> JavaType.FullyQualified.Kind.Annotation
+            else -> JavaType.FullyQualified.Kind.Class
+        }
+    }
+
+    private fun mapToFlagsBitmap(visibility: DescriptorVisibility): Long {
+        return mapToFlagsBitmap(visibility, null)
+    }
+
+    private fun mapToFlagsBitmap(visibility: DescriptorVisibility, modality: Modality?): Long {
+        var bitMask: Long = 0
+
+        when (visibility.externalDisplayName.lowercase()) {
+            "public" -> bitMask += 1L
+            "private" -> bitMask += 1L shl 1
+            "protected" -> bitMask += 1L shl 2
+            "internal", "package-private" -> {}
+            else -> {
+                throw UnsupportedOperationException("Unsupported visibility: ${visibility.name.lowercase()}")
+            }
+        }
+
+        if (modality != null) {
+            bitMask += when (modality.name.lowercase()) {
+                "final" -> 1L shl 4
+                "abstract" -> 1L shl 10
+                "sealed" -> 1L shl 62
+                "open" -> 0
+                else -> {
+                    throw UnsupportedOperationException("Unsupported modality: ${modality.name.lowercase()}")
+                }
+            }
+        }
+        return bitMask
+    }
+
+    private fun isNotAny(type: IrType): Boolean {
+        return !(type.classifierOrNull != null && type.classifierOrNull!!.owner is IrClass && "kotlin.Any" == (type.classifierOrNull!!.owner as IrClass).kotlinFqName.asString())
+    }
+}

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinIrTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinIrTypeMapping.kt
@@ -331,11 +331,18 @@ class KotlinIrTypeMapping(typeCache: JavaTypeCache) : JavaTypeMapping<Any> {
     private fun typeProjection(type: Any, signature: String): JavaType {
         val gtv = when (type) {
             is IrTypeProjection -> {
-                GenericTypeVariable(null, "?", if (type.variance == Variance.OUT_VARIANCE) COVARIANT else CONTRAVARIANT, listOf(type(type.type)))
+                GenericTypeVariable(
+                    null,
+                    "?",
+                    if (type.variance == Variance.OUT_VARIANCE) COVARIANT else CONTRAVARIANT,
+                    listOf(type(type.type))
+                )
             }
+
             is IrStarProjection -> {
                 GenericTypeVariable(null, "*", INVARIANT, null)
             }
+
             else -> {
                 throw UnsupportedOperationException("Unexpected type projection: " + type.javaClass)
             }

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilder.kt
@@ -1,0 +1,213 @@
+package org.openrewrite.kotlin
+
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
+import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.packageFqName
+import org.jetbrains.kotlin.types.Variance
+import org.openrewrite.java.JavaTypeSignatureBuilder
+import java.util.*
+
+class KotlinTypeIrSignatureBuilder : JavaTypeSignatureBuilder {
+    private var typeVariableNameStack: MutableSet<String>? = null
+
+    override fun signature(type: Any?): String {
+        if (type == null || type is IrErrorType) {
+            return "{undefined}"
+        }
+
+        if (type is IrClassifierSymbol) {
+            return signature(type.owner)
+        }
+
+        val baseType = if (type is IrSimpleType) type.classifier.owner else type
+
+        when (baseType) {
+            is IrFile -> {
+                return fileSignature(baseType)
+            }
+
+            is IrClass -> {
+                // The IrSimpleType may contain bounded type arguments
+                val useSimpleType = (type is IrSimpleType && (type.arguments.isNotEmpty() || type.annotations.isNotEmpty()))
+                return if (baseType.typeParameters.isEmpty()) classSignature(baseType) else parameterizedSignature(if (useSimpleType) type else baseType)
+            }
+
+            is IrFunction -> {
+                return methodDeclarationSignature(baseType)
+            }
+
+            is IrProperty -> {
+                return variableSignature(baseType)
+            }
+
+            is IrVariable -> {
+                TODO("IrVariable not yet implemented.")
+            }
+
+            is IrField -> {
+                TODO("IrField not yet implemented.")
+            }
+
+            is IrTypeAlias -> {
+                TODO("IrTypeAlias not yet implemented.")
+            }
+
+            is IrScript -> {
+                TODO("IrScript not yet implemented.")
+            }
+
+            is IrConstructorCall -> {
+                TODO("IrConstructorCall not yet implemented.")
+            }
+
+            is IrTypeProjection, is IrStarProjection -> {
+                return typeProjection(baseType)
+            }
+
+            is IrTypeParameter -> {
+                return genericSignature(baseType)
+            }
+        }
+
+        throw IllegalStateException("Unexpected type " + baseType.javaClass.getName())
+    }
+
+    private fun fileSignature(type: Any): String {
+        if (type !is IrFile) {
+            TODO()
+        }
+
+        return (if (type.fqName.asString().isNotEmpty()) type.fqName.asString() + "." else "") + type.name.replace(".kt", "Kt")
+    }
+
+    /**
+     * Kotlin does not support dimensioned arrays.
+     */
+    override fun arraySignature(type: Any): String {
+        throw UnsupportedOperationException("This should never happen.")
+    }
+
+    override fun classSignature(type: Any): String {
+        if (type !is IrClass) {
+            TODO("Not yet implemented")
+        }
+        val sb = StringBuilder()
+        // TODO: review how Method parents should be represented.
+        if (type.parent is IrClass) {
+            sb.append(classSignature(type.parent)).append("$")
+        } else if (type.packageFqName != null) {
+            sb.append(type.packageFqName).append(".")
+        }
+        sb.append(type.name)
+        return sb.toString()
+    }
+
+    override fun genericSignature(type: Any): String {
+        val typeParameter: IrTypeParameter = type as IrTypeParameter
+        val name = typeParameter.name.asString()
+
+        if (typeVariableNameStack == null) {
+            typeVariableNameStack = HashSet()
+        }
+
+        if (!typeVariableNameStack!!.add(name)) {
+            return "Generic{$name}"
+        }
+
+        val s = StringBuilder("Generic{").append(name)
+        val boundSigs = StringJoiner(" & ")
+        for (bound in typeParameter.superTypes) {
+            if (isNotAny(bound)) {
+                boundSigs.add(signature(bound))
+            }
+        }
+        val boundSigStr = boundSigs.toString()
+        if (boundSigStr.isNotEmpty()) {
+            s.append(" extends ").append(boundSigStr)
+        }
+        typeVariableNameStack!!.remove(name)
+        return s.append("}").toString()
+    }
+
+    private fun typeProjection(type: Any): String {
+        val sig = StringBuilder("Generic{")
+        when (type) {
+            is IrTypeProjection -> {
+                sig.append("?")
+                sig.append(if (type.variance == Variance.OUT_VARIANCE) " extends " else " super ")
+                sig.append(signature(type.type))
+            }
+            is IrStarProjection -> {
+                sig.append("*")
+            }
+            else -> {
+                TODO()
+            }
+        }
+        return sig.append("}").toString()
+    }
+
+    override fun parameterizedSignature(type: Any): String {
+        if (type !is IrSimpleType && type !is IrClass) {
+            TODO("Not yet implemented")
+        }
+
+        val s = StringBuilder(classSignature(if (type is IrSimpleType) type.classifier.owner else type))
+        val joiner = StringJoiner(", ", "<", ">")
+        val params = if (type is IrSimpleType) type.arguments else (type as IrClass).typeParameters
+        for (tp in params) {
+            joiner.add(signature(tp))
+        }
+        s.append(joiner)
+        return s.toString()
+    }
+
+    override fun primitiveSignature(type: Any): String {
+        TODO("Not yet implemented")
+    }
+
+    fun variableSignature(
+        property: IrProperty
+    ): String {
+        val owner = if (property.parent is IrClass) classSignature(property.parent) else signature(property.parent)
+        val typeSig = if (property.getter != null) {
+            signature(property.getter!!.returnType)
+        } else if (property.backingField != null) {
+            signature(property.backingField!!.type)
+        } else {
+            TODO()
+        }
+        return "$owner{name=${property.name.asString()},type=$typeSig}"
+    }
+
+    fun methodDeclarationSignature(function: IrFunction): String {
+        val parent = when (function.parent) {
+            is IrClass -> classSignature(function.parent)
+            else -> signature(function.parent)
+        }
+        val signature = StringBuilder(parent)
+        if (function is IrConstructor) {
+            signature.append("{name=<constructor>,return=$parent")
+        } else {
+            signature.append("{name=").append(function.name.asString())
+            signature.append(",return=").append(signature(function.returnType))
+        }
+        signature.append(",parameters=").append(methodArgumentSignature(function)).append("}")
+        return signature.toString()
+    }
+
+    private fun methodArgumentSignature(function: IrFunction): String {
+        val genericArgumentTypes = StringJoiner(",", "[", "]")
+        for (param: IrValueParameter in function.valueParameters) {
+            genericArgumentTypes.add(signature(param.type))
+        }
+        return genericArgumentTypes.toString()
+    }
+
+    private fun isNotAny(type: IrType): Boolean {
+        return !(type.classifierOrNull != null && type.classifierOrNull!!.owner is IrClass && "kotlin.Any" == (type.classifierOrNull!!.owner as IrClass).kotlinFqName.asString())
+    }
+}

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -105,7 +105,6 @@ class KotlinParserVisitor(
     private val charsetBomMarked: Boolean
     private val styles: List<NamedStyles>
     private val typeMapping: KotlinTypeMapping
-    private val irTypeMapping: KotlinIrTypeMapping
     private val data: ExecutionContext
     private val firSession: FirSession
     private var cursor = 0
@@ -116,8 +115,6 @@ class KotlinParserVisitor(
     private val ownerStack: ArrayDeque<FirDeclaration> = ArrayDeque()
     private var aliasImportMap: MutableMap<String, String>
 
-    private var irFile: IrFile
-
     init {
         sourcePath = kotlinSource.input.getRelativePath(relativeTo)
         fileAttributes = kotlinSource.input.fileAttributes
@@ -127,8 +124,6 @@ class KotlinParserVisitor(
         charsetBomMarked = `is`.isCharsetBomMarked
         this.styles = styles
         typeMapping = KotlinTypeMapping(typeCache, firSession, kotlinSource.firFile!!.symbol)
-        irTypeMapping = KotlinIrTypeMapping(typeCache)
-        irFile = kotlinSource.irFile!!
         this.data = data
         this.firSession = firSession
         this.nodes = kotlinSource.nodes
@@ -139,7 +134,6 @@ class KotlinParserVisitor(
     private fun type(obj: Any?, ownerFallBack: FirBasedSymbol<*>? = null) = typeMapping.type(obj, ownerFallBack)
 
     override fun visitFile(file: FirFile, data: ExecutionContext): J {
-        irTypeMapping.type(irFile)
         ownerStack.push(file)
         generatedFirProperties.clear()
         var annotations: List<J.Annotation>? = null

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinSource.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinSource.kt
@@ -20,6 +20,7 @@ import lombok.Setter
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.fir.declarations.FirFile
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.openrewrite.Parser
@@ -35,6 +36,9 @@ class KotlinSource(
 
     @Setter
     var firFile: FirFile? = null
+
+    @Setter
+    var irFile: IrFile? = null
 
     init {
         nodes = map(ktFile)

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilderTest.java
@@ -327,4 +327,12 @@ public class KotlinTypeIrSignatureBuilderTest {
         assertThat(methodSignature("javaType"))
           .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=javaType,return=kotlin.Unit,parameters=[java.lang.Object]}");
     }
+
+    @Test
+    void receiver() {
+        assertThat(firstMethodParameterSignature("receiver"))
+                .isEqualTo("org.openrewrite.kotlin.C");
+        assertThat(methodSignature("receiver"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=receiver,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.KotlinTypeGoat$TypeA,org.openrewrite.kotlin.C]}");
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.openrewrite.kotlin;
 
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable;
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer;
-import org.jetbrains.kotlin.fir.declarations.*;
 import org.jetbrains.kotlin.ir.declarations.*;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilderTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable;
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer;
+import org.jetbrains.kotlin.fir.declarations.*;
+import org.jetbrains.kotlin.ir.declarations.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.kotlin.internal.CompiledSource;
+import org.openrewrite.tree.ParsingExecutionContextView;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KotlinTypeIrSignatureBuilderTest {
+    private static final String goat = StringUtils.readFully(KotlinTypeIrSignatureBuilderTest.class.getResourceAsStream("/KotlinTypeGoat.kt"));
+
+    private static final Disposable disposable = Disposer.newDisposable();
+    private static final CompiledSource compiledSource = KotlinParser.builder()
+            .logCompilationWarningsAndErrors(true)
+            .moduleName("test")
+            .build()
+            .parse(singletonList(new Parser.Input(Paths.get("KotlinTypeGoat.kt"), () -> new ByteArrayInputStream(goat.getBytes(StandardCharsets.UTF_8)))), disposable,
+                    new ParsingExecutionContextView(new InMemoryExecutionContext(Throwable::printStackTrace)));
+
+    @AfterAll
+    static void afterAll() {
+        Disposer.dispose(disposable);
+    }
+
+    public KotlinTypeIrSignatureBuilder signatureBuilder() {
+        return new KotlinTypeIrSignatureBuilder();
+    }
+
+    private IrFile getCompiledSource() {
+        IrFile file = compiledSource.getSources().iterator().next().getIrFile();
+        assert file != null;
+        return file;
+    }
+
+    public String constructorSignature() {
+        return signatureBuilder().methodDeclarationSignature(getCompiledSource().getDeclarations().stream()
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .flatMap(it -> it.getDeclarations().stream())
+                .filter(IrConstructor.class::isInstance)
+                .map(IrConstructor.class::cast)
+                .findFirst()
+                .orElseThrow());
+    }
+
+    public Object innerClassSignature(String innerClassSimpleName) {
+        return signatureBuilder().signature(getCompiledSource().getDeclarations().stream()
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .flatMap(it -> it.getDeclarations().stream())
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .filter(it -> innerClassSimpleName.equals(it.getName().asString()))
+                .findFirst()
+                .orElseThrow()
+                .getSymbol());
+    }
+
+    public String fieldSignature(String field) {
+        return signatureBuilder().variableSignature(getCompiledSource().getDeclarations().stream()
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .flatMap(it -> it.getDeclarations().stream())
+                .filter(IrProperty.class::isInstance)
+                .map(IrProperty.class::cast)
+                .filter(it -> field.equals(it.getName().asString()))
+                .findFirst()
+                .orElseThrow());
+    }
+
+    @Nullable
+    public IrProperty getProperty(String field) {
+        return getCompiledSource().getDeclarations().stream()
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .flatMap(it -> it.getDeclarations().stream())
+                .filter(IrProperty.class::isInstance)
+                .map(IrProperty.class::cast)
+                .filter(it -> field.equals(it.getName().asString()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public String fieldPropertyGetterSignature(String field) {
+        IrProperty property = getProperty(field);
+        if (property == null || property.getGetter() == null) {
+            throw new UnsupportedOperationException("No filed or getter for " + field);
+        }
+        return signatureBuilder().methodDeclarationSignature(property.getGetter());
+    }
+
+    public String fieldPropertySetterSignature(String field) {
+        IrProperty property = getProperty(field);
+        if (property == null || property.getSetter() == null) {
+            throw new UnsupportedOperationException("No filed or setter for " + field);
+        }
+        return signatureBuilder().methodDeclarationSignature(property.getSetter());
+    }
+
+    public Object firstMethodParameterSignature(String methodName) {
+        return signatureBuilder().signature(getCompiledSource().getDeclarations().stream()
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .flatMap(it -> it.getDeclarations().stream())
+                .filter(IrFunction.class::isInstance)
+                .map(IrFunction.class::cast)
+                .filter(it -> methodName.equals(it.getName().asString()))
+                .findFirst()
+                .orElseThrow()
+                .getValueParameters()
+                .get(0)
+                .getType());
+    }
+
+    public Object lastClassTypeParameter() {
+        return signatureBuilder().signature(getCompiledSource().getDeclarations().stream()
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .findFirst()
+                .orElseThrow()
+                .getTypeParameters()
+                .get(1));
+    }
+
+    public String methodSignature(String methodName) {
+        return signatureBuilder().methodDeclarationSignature(getCompiledSource().getDeclarations().stream()
+                .filter(IrClass.class::isInstance)
+                .map(IrClass.class::cast)
+                .flatMap(it -> it.getDeclarations().stream())
+                .filter(IrFunction.class::isInstance)
+                .map(IrFunction.class::cast)
+                .filter(it -> methodName.equals(it.getName().asString()))
+                .findFirst()
+                .orElseThrow());
+    }
+
+    @Test
+    void fileField() {
+        IrProperty property = getCompiledSource().getDeclarations().stream()
+          .filter(it -> it instanceof IrProperty && "field".equals(((IrProperty) it).getName().asString()))
+          .map(it -> (IrProperty) it).findFirst().orElseThrow();
+        assertThat(signatureBuilder().variableSignature(property))
+          .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoatKt{name=field,type=kotlin.Int}");
+    }
+
+    @Test
+    void fileFunction() {
+        IrFunction function = getCompiledSource().getDeclarations().stream()
+          .filter(it -> it instanceof IrFunction && "function".equals(((IrFunction) it).getName().asString()))
+          .map(it -> (IrFunction) it).findFirst().orElseThrow();
+        assertThat(signatureBuilder().methodDeclarationSignature(function))
+          .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoatKt{name=function,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.C]}");
+    }
+
+    @Test
+    void constructor() {
+        assertThat(constructorSignature())
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=<constructor>,return=org.openrewrite.kotlin.KotlinTypeGoat,parameters=[]}");
+    }
+
+    @Test
+    void parameterizedField() {
+        assertThat(fieldSignature("parameterizedField"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=parameterizedField,type=org.openrewrite.kotlin.PT<org.openrewrite.kotlin.KotlinTypeGoat$TypeA>}");
+    }
+
+    @Test
+    void fieldType() {
+        assertThat(fieldSignature("field"))
+            .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=field,type=kotlin.Int}");
+    }
+
+    @Test
+    void gettableField() {
+        assertThat(fieldPropertyGetterSignature("field"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=<get-field>,return=kotlin.Int,parameters=[]}");
+    }
+
+    @Test
+    void settableField() {
+        assertThat(fieldPropertySetterSignature("field"))
+          .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=<set-field>,return=kotlin.Unit,parameters=[kotlin.Int]}");
+    }
+
+    @Test
+    void classSignature() {
+        assertThat(firstMethodParameterSignature("clazz"))
+                .isEqualTo("org.openrewrite.kotlin.C");
+        assertThat(methodSignature("clazz"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=clazz,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.C]}");
+    }
+
+    @Test
+    void parameterized() {
+        assertThat(firstMethodParameterSignature("parameterized"))
+                .isEqualTo("org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>");
+        assertThat(methodSignature("parameterized"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=parameterized,return=org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>,parameters=[org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>]}");
+    }
+
+    @Test
+    void parameterizedRecursive() {
+        assertThat(firstMethodParameterSignature("parameterizedRecursive"))
+                .isEqualTo("org.openrewrite.kotlin.PT<org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>>");
+        assertThat(methodSignature("parameterizedRecursive"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=parameterizedRecursive,return=org.openrewrite.kotlin.PT<org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>>,parameters=[org.openrewrite.kotlin.PT<org.openrewrite.kotlin.PT<org.openrewrite.kotlin.C>>]}");
+    }
+
+    @Test
+    void generic() {
+        assertThat(firstMethodParameterSignature("generic"))
+                .isEqualTo("org.openrewrite.kotlin.PT<Generic{? extends org.openrewrite.kotlin.C}>");
+        assertThat(methodSignature("generic"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=generic,return=org.openrewrite.kotlin.PT<Generic{? extends org.openrewrite.kotlin.C}>,parameters=[org.openrewrite.kotlin.PT<Generic{? extends org.openrewrite.kotlin.C}>]}");
+    }
+
+    @Test
+    void genericT() {
+        assertThat(firstMethodParameterSignature("genericT"))
+                .isEqualTo("Generic{T}");
+        assertThat(methodSignature("genericT"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericT,return=Generic{T},parameters=[Generic{T}]}");
+    }
+
+    @Test
+    void genericContravariant() {
+        assertThat(firstMethodParameterSignature("genericContravariant"))
+                .isEqualTo("org.openrewrite.kotlin.PT<Generic{? super org.openrewrite.kotlin.C}>");
+        assertThat(methodSignature("genericContravariant"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericContravariant,return=org.openrewrite.kotlin.PT<Generic{? super org.openrewrite.kotlin.C}>,parameters=[org.openrewrite.kotlin.PT<Generic{? super org.openrewrite.kotlin.C}>]}");
+    }
+
+    @Test
+    void genericUnbounded() {
+        assertThat(firstMethodParameterSignature("genericUnbounded"))
+                .isEqualTo("org.openrewrite.kotlin.PT<Generic{U}>");
+        assertThat(methodSignature("genericUnbounded"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericUnbounded,return=org.openrewrite.kotlin.PT<Generic{U}>,parameters=[org.openrewrite.kotlin.PT<Generic{U}>]}");
+    }
+
+    @Test
+    void innerClass() {
+        assertThat(firstMethodParameterSignature("inner"))
+                .isEqualTo("org.openrewrite.kotlin.C$Inner");
+        assertThat(methodSignature("inner"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=inner,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.C$Inner]}");
+    }
+
+    @Test
+    void inheritedKotlinTypeGoat() {
+        assertThat(firstMethodParameterSignature("inheritedKotlinTypeGoat"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat$InheritedKotlinTypeGoat<Generic{T}, Generic{U extends org.openrewrite.kotlin.PT<Generic{U}> & org.openrewrite.kotlin.C}>");
+        assertThat(methodSignature("inheritedKotlinTypeGoat"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=inheritedKotlinTypeGoat,return=org.openrewrite.kotlin.KotlinTypeGoat$InheritedKotlinTypeGoat<Generic{T}, Generic{U extends org.openrewrite.kotlin.PT<Generic{U}> & org.openrewrite.kotlin.C}>,parameters=[org.openrewrite.kotlin.KotlinTypeGoat$InheritedKotlinTypeGoat<Generic{T}, Generic{U extends org.openrewrite.kotlin.PT<Generic{U}> & org.openrewrite.kotlin.C}>]}");
+    }
+
+    @Disabled("Requires reference of type params from parent class")
+    @Test
+    void extendsJavaTypeGoat() {
+        assertThat(innerClassSignature("ExtendsKotlinTypeGoat"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat$ExtendsKotlinTypeGoat");
+    }
+
+    @Test
+    void genericIntersection() {
+        assertThat(firstMethodParameterSignature("genericIntersection"))
+                .isEqualTo("Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat$TypeA & org.openrewrite.kotlin.PT<Generic{U}> & org.openrewrite.kotlin.C}");
+        assertThat(methodSignature("genericIntersection"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericIntersection,return=Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat$TypeA & org.openrewrite.kotlin.PT<Generic{U}> & org.openrewrite.kotlin.C},parameters=[Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat$TypeA & org.openrewrite.kotlin.PT<Generic{U}> & org.openrewrite.kotlin.C}]}");
+    }
+
+    @Test
+    void recursiveIntersection() {
+        assertThat(firstMethodParameterSignature("recursiveIntersection"))
+                .isEqualTo("Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat$Extension<Generic{U}> & org.openrewrite.kotlin.Intersection<Generic{U}>}");
+        assertThat(methodSignature("recursiveIntersection"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=recursiveIntersection,return=kotlin.Unit,parameters=[Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat$Extension<Generic{U}> & org.openrewrite.kotlin.Intersection<Generic{U}>}]}");
+    }
+
+    @Test
+    void genericRecursiveInClassDefinition() {
+        assertThat(lastClassTypeParameter())
+                .isEqualTo("Generic{S extends org.openrewrite.kotlin.PT<Generic{S}> & org.openrewrite.kotlin.C}");
+    }
+
+    @Test
+    void genericRecursiveInMethodDeclaration() {
+        assertThat(firstMethodParameterSignature("genericRecursive"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat<Generic{? extends kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>");
+        assertThat(methodSignature("genericRecursive"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=genericRecursive,return=org.openrewrite.kotlin.KotlinTypeGoat<Generic{? extends kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>,parameters=[org.openrewrite.kotlin.KotlinTypeGoat<Generic{? extends kotlin.Array<Generic{U extends org.openrewrite.kotlin.KotlinTypeGoat<Generic{U}, Generic{*}>}>}, Generic{*}>]}");
+    }
+
+    @Test
+    void javaReference() {
+        assertThat(firstMethodParameterSignature("javaType"))
+          .isEqualTo("java.lang.Object");
+        assertThat(methodSignature("javaType"))
+          .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=javaType,return=kotlin.Unit,parameters=[java.lang.Object]}");
+    }
+}

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.kotlin;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
@@ -330,6 +331,13 @@ public class KotlinTypeMappingTest {
         JavaType.Method clazzMethod = methodType("clazz");
         assertThat(clazzMethod.getAnnotations()).hasSize(1);
         assertThat(clazzMethod.getAnnotations().get(0).getClassName()).isEqualTo("AnnotationWithRuntimeRetention");
+    }
+
+    @Disabled
+    @Test
+    void receiver() {
+        JavaType.Method receiverMethod = methodType("receiver");
+        assertThat(receiverMethod.toString()).isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=receiver,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.KotlinTypeGoat$TypeA,org.openrewrite.kotlin.C]}");
     }
 
     @Test

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -476,6 +476,7 @@ public class KotlinTypeMappingTest {
             );
         }
 
+        @SuppressWarnings({"KotlinConstantConditions", "UnusedUnaryOperator", "RedundantExplicitType"})
         @Test
         void whenExpression() {
             //noinspection RemoveRedundantQualifierName

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
@@ -330,4 +330,12 @@ public class KotlinTypeSignatureBuilderTest {
         assertThat(methodSignature("javaType"))
           .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=javaType,return=kotlin.Unit,parameters=[java.lang.Object]}");
     }
+
+    @Test
+    void receiver() {
+        assertThat(firstMethodParameterSignature("receiver"))
+                .isEqualTo("org.openrewrite.kotlin.C");
+        assertThat(methodSignature("receiver"))
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=receiver,return=kotlin.Unit,parameters=[org.openrewrite.kotlin.KotlinTypeGoat$TypeA,org.openrewrite.kotlin.C]}");
+    }
 }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
@@ -31,6 +31,7 @@ import org.openrewrite.tree.ParsingExecutionContextView;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,7 +53,7 @@ public class KotlinTypeSignatureBuilderTest {
     }
 
     public KotlinTypeSignatureBuilder signatureBuilder() {
-        return new KotlinTypeSignatureBuilder(compiledSource.getFirSession(), compiledSource.getSources().iterator().next().getFirFile().getSymbol());
+        return new KotlinTypeSignatureBuilder(compiledSource.getFirSession(), Objects.requireNonNull(compiledSource.getSources().iterator().next().getFirFile()).getSymbol());
     }
 
     private FirFile getCompiledSource() {

--- a/src/test/resources/KotlinTypeGoat.kt
+++ b/src/test/resources/KotlinTypeGoat.kt
@@ -72,10 +72,9 @@ abstract class KotlinTypeGoat<T, S> where S: PT<S>, S: C {
     abstract fun <U> inheritedKotlinTypeGoat(n: InheritedKotlinTypeGoat<T, U>): InheritedKotlinTypeGoat<T, U> where U : PT<U>, U : C
     abstract fun <U> genericIntersection(n: U): U where U : TypeA, U : PT<U>, U : C
     abstract fun genericT(n: T): T // remove after signatures are common.
-
     abstract fun <U> recursiveIntersection(n: U) where U : Extension<U>, U : Intersection<U>
-
     abstract fun javaType(n: Object)
+    abstract fun TypeA.receiver(n: C)
 }
 
 interface C {


### PR DESCRIPTION
Changes:
- Types and signatures are mappable through the IR.
- IR-type signature builder tests pass.
- IR-type mapping tests require either testing through the IR or via the LST.
  - I'll add an IR test suite if we'd like one, and we can use the LST through the PSI to match types. Still determining if it's worth it. @kunli2 @knutwannheden, what do you think?

Notes:
- TypeReceivers will be more consistent due to how the symbols are associated with the IR tree.
- Both type mapping and signature building are much more straightforward since types are accessible on the IR tree.
- Parents are available on the tree elements, so it does not need to be inferred.
- inline functions like `println` have a parent class of `kotlin.io`, since the `ConsoleKt` name comes from a `JVM` annotation and is unavailable in the tree.
- generate methods like `equals`, `toString`, etc. are all included in the IR tree.