### PR TITLE
Add `K.Unary` to present `POSTFIX_EXPRESSION` like `!!`

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -298,6 +298,28 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         return t;
     }
 
+    public J visitUnary(K.Unary unary, P p) {
+        K.Unary u = unary;
+        u = u.withPrefix(visitSpace(u.getPrefix(), KSpace.Location.UNARY_PREFIX, p));
+        u = u.withMarkers(visitMarkers(u.getMarkers(), p));
+        Statement temp = (Statement) visitStatement(u, p);
+        if (!(temp instanceof K.Unary)) {
+            return temp;
+        } else {
+            u = (K.Unary) temp;
+        }
+        Expression temp2 = (Expression) visitExpression(u, p);
+        if (!(temp2 instanceof K.Unary)) {
+            return temp2;
+        } else {
+            u = (K.Unary) temp2;
+        }
+        u = u.getPadding().withOperator(visitLeftPadded(u.getPadding().getOperator(), JLeftPadded.Location.UNARY_OPERATOR, p));
+        u = u.withExpression(visitAndCast(u.getExpression(), p));
+        u = u.withType(visitType(u.getType(), p));
+        return u;
+    }
+
     public J visitWhen(K.When when, P p) {
         K.When w = when;
         w = w.withPrefix(visitSpace(w.getPrefix(), KSpace.Location.WHEN_PREFIX, p));

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -412,6 +412,21 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     }
 
     @Override
+    public J visitUnary(K.Unary unary, PrintOutputCapture<P> p) {
+        beforeSyntax(unary, Space.Location.UNARY_PREFIX, p);
+        switch (unary.getOperator()) {
+            case NotNull:
+            default:
+                visit(unary.getExpression(), p);
+                visitSpace(unary.getPadding().getOperator().getBefore(), Space.Location.UNARY_OPERATOR, p);
+                p.append("!!");
+                break;
+        }
+        afterSyntax(unary, p);
+        return unary;
+    }
+
+    @Override
     public J visitWhen(K.When when, PrintOutputCapture<P> p) {
         beforeSyntax(when, KSpace.Location.WHEN_PREFIX, p);
         p.append("when");

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2739,7 +2739,8 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         J j = expression.getBaseExpression().accept(this, data);
         IElementType referencedNameElementType = expression.getOperationReference().getReferencedNameElementType();
         if (referencedNameElementType == KtTokens.EXCLEXCL) {
-            j = j.withMarkers(j.getMarkers().addIfAbsent(new CheckNotNull(randomId(), prefix(expression.getOperationReference()))));
+            // j = j.withMarkers(j.getMarkers().addIfAbsent(new CheckNotNull(randomId(), prefix(expression.getOperationReference()))));
+            j = new K.Unary(randomId(), prefix(expression), Markers.EMPTY, padLeft(prefix(expression.getOperationReference()), K.Unary.Type.NotNull), (Expression) j, type(expression));
         } else if (referencedNameElementType == KtTokens.PLUSPLUS) {
             j = new J.Unary(randomId(), prefix(expression), Markers.EMPTY, padLeft(prefix(expression.getOperationReference()), J.Unary.Type.PostIncrement), (Expression) j, type(expression));
         } else if (referencedNameElementType == KtTokens.MINUSMINUS) {

--- a/src/main/java/org/openrewrite/kotlin/tree/KSpace.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/KSpace.java
@@ -54,6 +54,7 @@ public class KSpace {
         TOP_LEVEL_STATEMENT,
         TYPE_CONSTRAINTS_PREFIX,
         TYPE_REFERENCE_PREFIX,
+        UNARY_PREFIX,
         WHEN_PREFIX,
         WHEN_BRANCH_EXPRESSION,
     }

--- a/src/test/java/org/openrewrite/kotlin/tree/UnaryTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/UnaryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class UnaryTest implements RewriteTest {
+
+
+    @Test
+    void unary() {
+        rewriteRun(
+          kotlin(
+            """
+              var n = 0
+              val a =  n   --
+              val b =  --   n
+              """
+          )
+        );
+    }
+
+    @Test
+    void notNull() {
+        rewriteRun(
+          kotlin(
+            """
+              val l = listOf ( "x" )
+              val a = l [ 0 ] !!
+              """
+          )
+        );
+    }
+
+    @Test
+    void checkNotNull() {
+        rewriteRun(
+          kotlin(
+            """
+              class A {
+                  fun method ( ) : Int ? {
+                      return 1
+                  }
+              }
+              """
+          ),
+          kotlin(
+            """
+              val a = A ( )
+              val b = a . method ( ) !!
+              val c = b !!
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Use K.Unary to present `POSTFIX_EXPRESSION` like `!!`.

Currently, for the expression like `list [ 0 ] !!`

method invocation `list.get( 0 )` to present it a marker `CheckNotNull` with prefix.
Changed to involve `K.Unary` to present this and will deprecate marker `CheckNotNull`.

And also, `list [ 0 ]` should be a `J.ArrayAccess`.
