### PR TITLE
Switched to PSI-parser

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/AssertionsTest.java
+++ b/src/test/java/org/openrewrite/kotlin/AssertionsTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -57,5 +58,10 @@ public class AssertionsTest implements RewriteTest {
             """
           )
         );
+    }
+
+    @Test
+    void disablePublishingSnapshots() {
+        assertThat(true).isEqualTo(false);
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -15,13 +15,10 @@
  */
 package org.openrewrite.kotlin;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.Parser;
@@ -451,7 +448,6 @@ public class KotlinTypeMappingTest {
             );
         }
 
-        @Disabled("Enable with PSI parser")
         @Test
         void implicitInvoke() {
             rewriteRun(
@@ -540,7 +536,6 @@ public class KotlinTypeMappingTest {
             );
         }
 
-        @Disabled("Enable with PSI parser")
         @ParameterizedTest
         @CsvSource(value = {
           "n++~kotlin.Int",
@@ -592,7 +587,6 @@ public class KotlinTypeMappingTest {
             );
         }
 
-        @Disabled("Enable with PSI parser")
         @Test
         void operatorOverload() {
             rewriteRun(
@@ -667,21 +661,21 @@ public class KotlinTypeMappingTest {
                                   .isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>");
                                 case "a" -> {
                                     assertThat(variable.getVariableType().toString())
-                                      .isEqualTo("openRewriteFile0Kt{name=a,type=kotlin.Int}");
+                                      .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=a,type=kotlin.Int}");
                                     assertThat(variable.getInitializer()).isInstanceOf(J.MethodInvocation.class);
                                     assertThat(((J.MethodInvocation) variable.getInitializer()).getMethodType().toString())
                                       .isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>{name=component1,return=kotlin.Int,parameters=[]}");
                                 }
                                 case "b" -> {
                                     assertThat(variable.getVariableType().toString())
-                                      .isEqualTo("openRewriteFile0Kt{name=b,type=kotlin.Int}");
+                                      .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=b,type=kotlin.Int}");
                                     assertThat(variable.getInitializer()).isInstanceOf(J.MethodInvocation.class);
                                     assertThat(((J.MethodInvocation) variable.getInitializer()).getMethodType().toString())
                                       .isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>{name=component2,return=kotlin.Int,parameters=[]}");
                                 }
                                 case "c" -> {
                                     assertThat(variable.getVariableType().toString())
-                                      .isEqualTo("openRewriteFile0Kt{name=c,type=kotlin.Int}");
+                                      .isEqualTo("openRewriteFile0Kt{name=foo,return=kotlin.Unit,parameters=[]}{name=c,type=kotlin.Int}");
                                     assertThat(variable.getInitializer()).isInstanceOf(J.MethodInvocation.class);
                                     assertThat(((J.MethodInvocation) variable.getInitializer()).getMethodType().toString())
                                       .isEqualTo("kotlin.Triple<kotlin.Int, kotlin.Int, kotlin.Int>{name=component3,return=kotlin.Int,parameters=[]}");
@@ -737,6 +731,5 @@ public class KotlinTypeMappingTest {
               )
             );
         }
-        // TODO: ensure method and variable types from various IR with the same types generate the same java type.
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/ArrayTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ArrayTest.java
@@ -94,7 +94,7 @@ class ArrayTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Fixed by PSI-based-parser")
+    @ExpectedToFail("array[0]++ is mapped to 9 Fake elements. Find a way to retrieve the correct FIR.")
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/291")
     void incrementArrayElement() {
@@ -108,7 +108,6 @@ class ArrayTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Fixed by PSI-based-parser")
     @Test
     void IndexedAccessOperator2D() {
         rewriteRun(
@@ -129,7 +128,6 @@ class ArrayTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Fixed by PSI-based-parser")
     @Test
     void IndexAccessOperatorMulD() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/kotlin/tree/AssignmentOperationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AssignmentOperationTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -117,7 +116,6 @@ class AssignmentOperationTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Fixed by psi-based-parser")
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/305")
     void augmentedAssignmentAnnotation() {

--- a/src/test/java/org/openrewrite/kotlin/tree/CastTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/CastTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -40,7 +39,6 @@ class CastTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/276")
-    @ExpectedToFail
     void parenthesized() {
         rewriteRun(
           kotlin(
@@ -51,7 +49,6 @@ class CastTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/276")
     void parenthesize2() {

--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.kotlin.tree;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
@@ -162,7 +161,6 @@ class ClassDeclarationTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Fixed by PSI-based-parser")
     @Test
     void annotationClass() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/kotlin/tree/CommentTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/CommentTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.kotlin.tree;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -81,7 +80,6 @@ class CommentTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Only supported by psi-based parser")
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/320")
     @Test
     void nestedComment() {

--- a/src/test/java/org/openrewrite/kotlin/tree/FunctionTypeTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/FunctionTypeTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -96,7 +95,6 @@ class FunctionTypeTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/292")
-    @ExpectedToFail
     void functionTypeParentheses() {
         rewriteRun(
           kotlin(

--- a/src/test/java/org/openrewrite/kotlin/tree/IdentifierTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/IdentifierTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -24,7 +23,6 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class IdentifierTest implements RewriteTest {
 
-    @ExpectedToFail("fixed by PSI-based parser")
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/296")
     void quotedIdentifier() {

--- a/src/test/java/org/openrewrite/kotlin/tree/IfTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/IfTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
@@ -155,7 +154,6 @@ class IfTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Fixed by PSI based parser")
     @Test
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/298")
     void functionCallCondition() {


### PR DESCRIPTION
Changes:

- Removed FIR-based parsing from parsing inputs.
- Removed IR file generation until we can switch to IR-type mapping.
- Removed expected to fail.
- Added `disablePublishingSnapshots` as a failing test to prevent publishing snapshots. The test may be removed if @knutwannheden thinks the changes will be fine with the SAAS.