### PR TITLE
Fix ChangeType and FindFieldAccess tests.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -18,7 +18,6 @@ package org.openrewrite.kotlin.internal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.KtNodeTypes;
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode;
-import org.jetbrains.kotlin.com.intellij.openapi.util.Pair;
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange;
 import org.jetbrains.kotlin.com.intellij.psi.*;
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -18,6 +18,7 @@ package org.openrewrite.kotlin.internal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.KtNodeTypes;
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode;
+import org.jetbrains.kotlin.com.intellij.openapi.util.Pair;
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange;
 import org.jetbrains.kotlin.com.intellij.psi.*;
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement;
@@ -1831,13 +1832,26 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     parameters.add(padRight(convertToExpression(ktTypeProjection.accept(this, data)), suffix(ktTypeProjection)));
                 }
 
+                JavaType javaType = type(expression);
+                JavaType nameType = JavaType.Unknown.getInstance();
+                JavaType pt = JavaType.Unknown.getInstance();
+                if (javaType instanceof JavaType.Method) {
+                    pt = ((JavaType.Method) javaType).getReturnType();
+                } else if (javaType instanceof JavaType.Variable) {
+                    pt = ((JavaType.Variable) javaType).getType();
+                } else if (javaType instanceof JavaType.Parameterized) {
+                    pt = javaType;
+                }
+                if (pt instanceof JavaType.Parameterized) {
+                    nameType = ((JavaType.Parameterized) pt).getType();
+                }
                 name = new J.ParameterizedType(
                         randomId(),
                         name.getPrefix(),
                         Markers.EMPTY,
-                        name.withType(name.getType() instanceof JavaType.Parameterized ? ((JavaType.Parameterized) name.getType()).getType() : name.getType()).withPrefix(Space.EMPTY),
+                        name.withType(nameType).withPrefix(Space.EMPTY),
                         JContainer.build(prefix(expression.getTypeArgumentList()), parameters, Markers.EMPTY),
-                        type(expression)
+                        pt
                 );
             }
 
@@ -2255,16 +2269,48 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             KtCallExpression callExpression = (KtCallExpression) expression.getSelectorExpression();
             MethodCall methodInvocation = (MethodCall) callExpression.accept(this, data);
 
-            expression.getReceiverExpression();
             Expression receiver = convertToExpression(expression.getReceiverExpression().accept(this, data));
             if (methodInvocation instanceof J.MethodInvocation) {
                 methodInvocation = ((J.MethodInvocation) methodInvocation).getPadding().withSelect(padRight(receiver, suffix(expression.getReceiverExpression())))
                         .withName(((J.MethodInvocation) methodInvocation).getName().withPrefix(prefix(callExpression)))
                         .withPrefix(prefix(expression));
             } else if (methodInvocation instanceof J.NewClass) {
-                methodInvocation = ((J.NewClass) methodInvocation).getPadding().withEnclosing(padRight(receiver, suffix(expression.getReceiverExpression())))
-                        .withClazz(((J.NewClass) methodInvocation).getClazz().withPrefix(prefix(callExpression)))
-                        .withPrefix(prefix(expression));
+                if (receiver instanceof J.FieldAccess) {
+                    J.NewClass cur = (J.NewClass) methodInvocation;
+                    if (cur.getClazz() instanceof J.ParameterizedType) {
+                        cur = cur.withPrefix(prefix(expression));
+                        J.ParameterizedType pt = (J.ParameterizedType) cur.getClazz();
+                        if (pt != null) {
+                            pt = pt.withClazz(pt.getClazz().withPrefix(prefix(callExpression)));
+                            J.FieldAccess newName = new J.FieldAccess(
+                                    randomId(),
+                                    receiver.getPrefix(),
+                                    Markers.EMPTY,
+                                    receiver.withPrefix(Space.EMPTY),
+                                    padLeft(suffix(expression.getReceiverExpression()), (J.Identifier) pt.getClazz()),
+                                    pt.getType()
+                            );
+                            pt = pt.withClazz(newName);
+                            cur = cur.withClazz(pt);
+                        }
+                        methodInvocation = cur;
+                    } else {
+                        cur = cur.withPrefix(prefix(expression));
+                        J.Identifier id = (J.Identifier) cur.getClazz();
+                        if (id != null) {
+                            id = id.withPrefix(prefix(callExpression));
+                            J.FieldAccess newName = new J.FieldAccess(
+                                    randomId(),
+                                    receiver.getPrefix(),
+                                    Markers.EMPTY,
+                                    receiver.withPrefix(Space.EMPTY),
+                                    padLeft(suffix(expression.getReceiverExpression()), id),
+                                    id.getType()
+                            );
+                            methodInvocation = cur.withClazz(newName);
+                        }
+                    }
+                }
             }
 
             return methodInvocation;

--- a/src/test/java/org/openrewrite/kotlin/tree/FieldAccessTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/FieldAccessTest.java
@@ -31,6 +31,32 @@ import static org.openrewrite.test.RewriteTest.toRecipe;
 class FieldAccessTest implements RewriteTest {
 
     @Test
+    void fieldAccessOnParameterizedType() {
+        rewriteRun(
+          kotlin(
+            """
+              class Foo {
+                val s =/*1*/java/*2*/./*3*/util/*4*/./*5*/ArrayList<String>()/*6*/./*7*/toString()
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldAccessOnIdentifier() {
+        rewriteRun(
+          kotlin(
+            """
+              class Foo {
+                val sb = /*1*/java/*2*/./*3*/lang/*4*/./*5*/StringBuilder()/*6*/./*7*/toString()
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void thisAccess() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
Updates:

- Fully qualified dot qualified call expressions with generate the correct tree with appropriate types.
- PropertyAccessExpression will resolve the callee reference instead of type typeref.
  - Prior to the changes `java.lang.Integer` was set to `kotlin.Int`.