### PR TITLE
Fix null JavaClassifierType case

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     testRuntimeOnly("com.squareup.misk:misk-metrics:latest.release")
 
     testImplementation("com.github.ajalt.clikt:clikt:3.5.0")
+    testImplementation("com.squareup:javapoet:1.13.0")
+    testImplementation("com.google.testing.compile:compile-testing:0.+")
 }
 
 val compileKotlin: KotlinCompile by tasks

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -731,5 +731,32 @@ public class KotlinTypeMappingTest {
               )
             );
         }
+
+        @Test
+        void nullJavaClassifierType() {
+            rewriteRun(
+              spec -> spec.parser(KotlinParser.builder().classpath("javapoet","compile-testing")),
+              kotlin(
+                """
+                  package org.openrewrite.kotlin
+
+                  import com.google.testing.compile.Compilation
+                  import com.google.testing.compile.CompilationSubject
+                  import com.google.testing.compile.Compiler.javac
+                  import com.squareup.javapoet.JavaFile
+
+                  class Test {
+                      fun assertCompilesJava(javaFiles: Collection<JavaFile>): Compilation {
+                          val result = javac()
+                              .withOptions("-parameters")
+                              .compile(javaFiles.map(JavaFile::toJavaFileObject))
+                          CompilationSubject.assertThat(result).succeededWithoutWarnings()
+                          return result
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
Got this parsing error when parsing repo `dgs-codegen` locally.
Caused by null `JavaClassifierType.classifier`.
Please take the test case in this PR as an example.