### PR TITLE
Updated `KotlinTypeMapping#methodInvocationType` to use symbol to set paramNames list instead of function.

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -502,6 +502,21 @@ public class KotlinTypeMappingTest {
             );
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/366")
+        @Test
+        void doesNotNpe() {
+            rewriteRun(
+              kotlin(
+                """
+                  class BuilderClass
+                  class A {
+                      val builder = BuilderClass::class.java.constructors[0].newInstance()!!
+                  }
+                  """
+              )
+            );
+        }
+
         @Test
         void println() {
             //noinspection RemoveRedundantQualifierName


### PR DESCRIPTION
Changes:

- `KotlinTypeMapping#methodInvocationType` will not NPE on null `paramTypes`.

fixes #336