### PR TITLE
Optimize PsiElementAssociations filtering, to filter FirUserTypeRef since it produce no type

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.kotlin.internal
 
-import org.jetbrains.kotlin.KtFakeSourceElement
 import org.jetbrains.kotlin.KtRealPsiSourceElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.fir.FirElement
@@ -34,6 +33,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.FirUserTypeRef
 import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
 import org.jetbrains.kotlin.psi
 import org.jetbrains.kotlin.psi.*
@@ -70,7 +70,12 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
     }
 
     fun primary(psiElement: PsiElement) =
-        fir(psiElement) { it.source is KtRealPsiSourceElement }
+        fir(psiElement) { filterFirElement(it) }
+
+    private fun filterFirElement(firElement : FirElement) : Boolean {
+        return firElement.source is KtRealPsiSourceElement &&
+                firElement !is FirUserTypeRef
+    }
 
     fun methodDeclarationType(psi: PsiElement): JavaType.Method? {
         return when (val fir = primary(psi)) {


### PR DESCRIPTION
I see this exception when running `rewrite-kotlin` parser locally on repo `dgs-codegen`
```
There were problems parsing graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
java.lang.UnsupportedOperationException: java type is not a Parameterized
  org.openrewrite.kotlin.internal.KotlinTreeParserVisitor.visitUserType(KotlinTreeParserVisitor.java:3077)
  org.openrewrite.kotlin.internal.KotlinTreeParserVisitor.visitUserType(KotlinTreeParserVisitor.java:69)
  org.jetbrains.kotlin.psi.KtUserType.accept(KtUserType.java:42)
  org.openrewrite.kotlin.internal.KotlinTreeParserVisitor.visitTypeReference(KotlinTreeParserVisitor.java:3026)
  org.openrewrite.kotlin.internal.KotlinTreeParserVisitor.visitTypeReference(KotlinTreeParserVisitor.java:69)
  org.jetbrains.kotlin.psi.KtTypeReference.accept(KtTypeReference.kt:38)
  org.openrewrite.kotlin.internal.KotlinTreeParserVisitor.visitProperty(KotlinTreeParserVisitor.java:2827)
  org.openrewrite.kotlin.internal.KotlinTreeParserVisitor.visitProperty(KotlinTreeParserVisitor.java:69)
  ...
```
In that case, there are 3 FirElements associated with the PSI. the 1st one is `FirUserTypeRef` which produces no type, and the others have the correct types, so update the filtering condition to filter`FirUserTypeRef`.