### PR TITLE
Print syntax errors for visibility in tests, and polish test.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -173,7 +173,7 @@ public class KotlinParser implements Parser {
                                         assert kotlinSource.getFirFile().getSource() != null;
                                         PsiElement psi = ((KtRealPsiSourceElement) kotlinSource.getFirFile().getSource()).getPsi();
                                         AnalyzerWithCompilerReport.SyntaxErrorReport report =
-                                                AnalyzerWithCompilerReport.Companion.reportSyntaxErrors(psi, MessageCollector.Companion.getNONE());
+                                                AnalyzerWithCompilerReport.Companion.reportSyntaxErrors(psi, new PrintingMessageCollector(System.err, PLAIN_FULL_PATHS, true));
                                         if (report.isHasErrors()) {
                                             return ParseError.build(KotlinParser.this, kotlinSource.getInput(), relativeTo, ctx, new RuntimeException());
                                         }

--- a/src/test/java/org/openrewrite/kotlin/AssertionsTest.java
+++ b/src/test/java/org/openrewrite/kotlin/AssertionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.kotlin;
 
+import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.ExecutionContext;
@@ -61,11 +62,17 @@ public class AssertionsTest implements RewriteTest {
         );
     }
 
+    /**
+     * This test is expected to fail due to invalid syntax and exists to prevent a regression in the compiler configuration.
+     * {@link AnalyzerWithCompilerReport} is used to analyze the syntax in each source to produce a ParserError if a syntax
+     * error exists in the source code.
+     */
     @ExpectedToFail
     @Test
     void invalidSyntax() {
         rewriteRun(
           kotlin(
+            //language=none
             """
               a++
               """


### PR DESCRIPTION
Changes:
- Syntax errors from `AnalyzerWithCompilerReport` are printed to System.err.
- Disabled language inspection on invalidSyntax.