### PR TITLE
Fixed type on import aliases.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/RenameTypeAlias.java
+++ b/src/main/java/org/openrewrite/kotlin/RenameTypeAlias.java
@@ -60,7 +60,7 @@ public class RenameTypeAlias extends Recipe {
                     return i;
                 }
                 if (!isVariableName(getCursor().getParentTreeCursor(), i) ||
-                        isAliasImport(getCursor().getParentTreeCursor(), i) ) {
+                        isAliasImport(getCursor().getParentTreeCursor(), i)) {
                     i = i.withSimpleName(newName);
                 }
                 return i;
@@ -86,20 +86,15 @@ public class RenameTypeAlias extends Recipe {
             Object maybeVd = cursor.getParentTreeCursor().getValue();
             if (maybeVd instanceof J.VariableDeclarations) {
                 J.VariableDeclarations vd = (J.VariableDeclarations) maybeVd;
-                if (vd.getLeadingAnnotations().stream().anyMatch(it -> "typealias".equals(it.getSimpleName()))) {
-                    return false;
-                }
+                return vd.getLeadingAnnotations().stream().noneMatch(it -> "typealias".equals(it.getSimpleName()));
             }
             return true;
-        } else if (value instanceof J.ParameterizedType) {
-            return false;
-        }
-        return true;
+        } else return !(value instanceof J.ParameterizedType);
     }
 
     private boolean isAliasImport(Cursor cursor, J.Identifier id) {
         if (cursor.getValue() instanceof J.Import) {
-            J.Import ji = (J.Import) cursor.getValue();
+            J.Import ji = cursor.getValue();
             return ji.getAlias() == id;
         }
 

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2411,8 +2411,8 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 Markers.EMPTY,
                 rpStatic,
                 (J.FieldAccess) reference,
-                // TODO: fix NPE.
-                alias != null ? padLeft(prefix(alias), createIdentifier(requireNonNull(alias.getNameIdentifier()), type(alias))) : null
+                // Aliases contain Kotlin `Name` and do not resolve to a type. The aliases type is the import directive, so we set the type to match the import.
+                alias != null ? padLeft(prefix(alias), createIdentifier(requireNonNull(alias.getNameIdentifier()), type(importDirective))) : null
         );
     }
 

--- a/src/test/java/org/openrewrite/kotlin/RenameTypeAliasTest.java
+++ b/src/test/java/org/openrewrite/kotlin/RenameTypeAliasTest.java
@@ -15,9 +15,7 @@
  */
 package org.openrewrite.kotlin;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -72,7 +70,6 @@ class RenameTypeAliasTest implements RewriteTest {
         );
     }
 
-    @Disabled("Require rewrite release to pass")
     @Test
     void aliasImport() {
         rewriteRun(
@@ -84,11 +81,13 @@ class RenameTypeAliasTest implements RewriteTest {
               """
           ),
           kotlin(
+            //language=none
             """
               import foo.Test as OldAlias
 
               val a : OldAlias = OldAlias()
               """,
+            //language=none
             """
               import foo.Test as NewAlias
 
@@ -121,12 +120,14 @@ class RenameTypeAliasTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
+              @file:Suppress("UNUSED_PARAMETER")
               class Test
               typealias OldAlias = Test
               fun method(a: OldAlias) {
               }
               """,
             """
+              @file:Suppress("UNUSED_PARAMETER")
               class Test
               typealias NewAlias = Test
               fun method(a: NewAlias) {


### PR DESCRIPTION
Changes:
- Alias name will contain the aliased type rather than JavaType$Unknown


Info:
`import foo.Test as OldAlias`

The FIR associated with a `KtImportAlias` contains Name objects that evaluate to strings since the import directive includes the symbol to the resolved type. `type(alias)` always returns `JavaType$Unknown` rather than the aliased type. So, I updated the method to `type(importDirective)`, so that the correct class is associated to the Alias name.

