### PR TITLE
Fixed import type resolution and super type references.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -17,6 +17,8 @@ package org.openrewrite.kotlin
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.builtins.PrimitiveType
+import org.jetbrains.kotlin.codegen.classId
+import org.jetbrains.kotlin.codegen.topLevelClassAsmType
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibility
@@ -33,6 +35,7 @@ import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.java.declarations.FirJavaField
 import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
+import org.jetbrains.kotlin.fir.references.FirSuperReference
 import org.jetbrains.kotlin.fir.references.toResolvedBaseSymbol
 import org.jetbrains.kotlin.fir.resolve.providers.toSymbol
 import org.jetbrains.kotlin.fir.resolve.toFirRegularClass
@@ -122,6 +125,10 @@ class KotlinTypeMapping(
                 Unknown.getInstance()
             }
 
+            is FirSuperReference -> {
+                type(type.superTypeRef, signature)
+            }
+
             is FirFile -> {
                 fileType(signature)
             }
@@ -132,6 +139,10 @@ class KotlinTypeMapping(
 
             is FirFunctionCall -> {
                 methodInvocationType(type, signature)
+            }
+
+            is FirImport -> {
+                resolveImport(type, signature)
             }
 
             is FirJavaTypeRef -> {
@@ -186,6 +197,13 @@ class KotlinTypeMapping(
                 Unknown.getInstance()
             }
         }
+    }
+
+    @OptIn(SymbolInternals::class)
+    private fun resolveImport(type: FirImport, signature: String): JavaType? {
+        // If the symbol is not resolvable we return a NEW ShallowClass to prevent caching on a potentially resolvable class type.
+        val sym = type.importedFqName?.topLevelClassAsmType()?.classId?.toSymbol(firSession) ?: return ShallowClass.build(signature)
+        return type(sym.fir, signature)
     }
 
     private fun packageDirective(signature: String): JavaType? {
@@ -290,15 +308,22 @@ class KotlinTypeMapping(
                         signature
                     )
                 }
-                val ref = type.toRegularClassSymbol(firSession)
+                var sym: Any? = type.toRegularClassSymbol(firSession)
                 if (type.typeArguments.isNotEmpty()) {
                     params = type.typeArguments.toList()
                 }
-                if (ref == null) {
-                    typeCache.put(signature, Unknown.getInstance())
-                    return Unknown.getInstance()
+
+                if (sym is FirRegularClassSymbol) {
+                    sym.fir
+                } else {
+                    sym = type.toSymbol(firSession)
+                    if (sym is FirClassLikeSymbol<*>) {
+                        sym.fir as FirClass
+                    } else {
+                        typeCache.put(signature, Unknown.getInstance())
+                        return Unknown.getInstance()
+                    }
                 }
-                ref.fir
             }
 
             else -> throw UnsupportedOperationException("Unexpected classType: ${type.javaClass}")
@@ -957,8 +982,7 @@ class KotlinTypeMapping(
         clazz = if (type.classifier != null) {
             TypeUtils.asFullyQualified(type(type.classifier!!))
         } else {
-            val fq : JavaType = buildType(type.classifierQualifiedName)
-            fq as FullyQualified
+            ShallowClass.build(type.classifierQualifiedName) as FullyQualified
         }
 
         if (type.typeArguments.isNotEmpty()) {

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -982,7 +982,7 @@ class KotlinTypeMapping(
         clazz = if (type.classifier != null) {
             TypeUtils.asFullyQualified(type(type.classifier!!))
         } else {
-            ShallowClass.build(type.classifierQualifiedName) as FullyQualified
+            createShallowClass(type.classifierQualifiedName)
         }
 
         if (type.typeArguments.isNotEmpty()) {

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -745,6 +745,23 @@ public class KotlinTypeMappingTest {
             );
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/373")
+        @Test
+        void javaTypeFullyQualified() {
+            rewriteRun(
+              kotlin(
+                """
+                  @file:Suppress("UNUSED_PARAMETER")
+                  open class Object<T>
+                  class Test(name: String, any: Any)
+                  
+                  fun <T> foo(name: String) =
+                      Test(name, object : Object<T>() {})
+                  """
+              )
+            );
+        }
+
         @Test
         void variableTypes() {
             rewriteRun(

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -465,7 +465,7 @@ class AnnotationTest implements RewriteTest {
     }
 
     @Test
-    void AnnotationEntryTrailingComma() {
+    void annotationEntryTrailingComma() {
         rewriteRun(
           spec -> spec.parser(KotlinParser.builder().classpath("jackson-annotations")),
           kotlin(

--- a/src/test/java/org/openrewrite/kotlin/tree/FieldAccessTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/FieldAccessTest.java
@@ -92,11 +92,11 @@ class FieldAccessTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              open class Super {
-                  val id : String = ""
+              open class A {
+                  val id : Int = 0
               }
-              class Test : Super() {
-                  fun getId ( ) : String {
+              class B : A ( ) {
+                  fun getId ( ) : Int {
                       return super . id
                   }
               }

--- a/src/test/java/org/openrewrite/kotlin/tree/ParenthesesTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ParenthesesTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
@@ -28,6 +27,7 @@ class ParenthesesTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
+              @Suppress("UNUSED_PARAMETER")
               class A {
                   internal fun <T> parseMappedType(
                       mappedType: (String),


### PR DESCRIPTION
Changes:

- Added type mapping and signature support for `FirAnonymousObject`, `FirImport` and `FirSuperReference`.
- `KotlinTypeMapping#classType()` will attempt to resolve the `FirClassLikeSymbol` if a `FirRegularClassSymbol` is not available to generate types for anonymous objects.
- An UnsupportedOperationException will be thrown if an FIR tree is not supported instead of returning an empty string.

fixes #344
fixes #376