### PR TITLE
Catch exceptions and create a J.Unknown in visitKtFile.

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/ClassDeclarationTest.java
@@ -30,15 +30,6 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 class ClassDeclarationTest implements RewriteTest {
 
     @Test
-    void whitespaceInPackage() {
-        rewriteRun(
-          kotlin(
-            "package foo . bar"
-          )
-        );
-    }
-
-    @Test
     void whitespaceInImport() {
         rewriteRun(
           kotlin(

--- a/src/test/java/org/openrewrite/kotlin/tree/PackageTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/PackageTest.java
@@ -24,6 +24,15 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 class PackageTest implements RewriteTest {
 
     @Test
+    void whitespaceInPackage() {
+        rewriteRun(
+          kotlin(
+            "package foo . bar"
+          )
+        );
+    }
+
+    @Test
     void regular() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
Changes:
- Exceptions thrown while creating statements are caught and converted to a J.Unknown with a ParseExceptionResult marker.