### PR TITLE
Added support for protected_static visibility in KotlinTypeMapping.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -1216,6 +1216,10 @@ class KotlinTypeMapping(
             "public" -> bitMask += 1L
             "private", "private_to_this" -> bitMask += 1L shl 1
             "protected", "protected_and_package" -> bitMask += 1L shl 2
+            "protected_static" -> {
+                bitMask += 1L shl 2
+                bitMask += 1L shl 3 // static
+            }
             "internal", "package", "local" -> {}
             else -> throw UnsupportedOperationException("Unsupported visibility: ${visibility.name.lowercase()}")
         }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -804,6 +804,19 @@ public class KotlinTypeMappingTest {
         }
 
         @Test
+        void packageStaticModifier() {
+            rewriteRun(
+              kotlin(
+                """
+                  import java.rmi.server.RemoteStub
+                  
+                  class A : RemoteStub()
+                  """
+              )
+            );
+        }
+
+        @Test
         void nullJavaClassifierType() {
             rewriteRun(
               spec -> spec.parser(KotlinParser.builder().classpath("javapoet","compile-testing")),


### PR DESCRIPTION
Changes:

- `protected_static` visibility will set the correct flags instead of throwing an `UnsupportedOperationException`.