### PR TITLE
Error on whitespace before type parameter annotation

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1436,13 +1436,9 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             }
             default: {
                 name = convertToExpression(requireNonNull(typeProjection.getTypeReference()).accept(this, data));
-                if (name instanceof J.Identifier) {
-                    J.Identifier id = (J.Identifier) name;
-                    if (!id.getAnnotations().isEmpty()) {
-                        name = id.withAnnotations(ListUtils.mapFirst(id.getAnnotations(), anno -> anno.withPrefix(merge(prefix(typeProjection), anno.getPrefix()))));
-                    } else {
-                        name = name.withPrefix(merge(prefix(typeProjection), name.getPrefix()));
-                    }
+                if (name instanceof J.Identifier && !((J.Identifier) name).getAnnotations().isEmpty()) {
+                    name = ((J.Identifier) name).withAnnotations(ListUtils.mapFirst(((J.Identifier)name).getAnnotations(),
+                            anno -> anno.withPrefix(merge(prefix(typeProjection), anno.getPrefix()))));
                 } else {
                     name = name.withPrefix(merge(prefix(typeProjection), name.getPrefix()));
                 }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1436,7 +1436,16 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             }
             default: {
                 name = convertToExpression(requireNonNull(typeProjection.getTypeReference()).accept(this, data));
-                name = name.withPrefix(merge(prefix(typeProjection), name.getPrefix()));
+                if (name instanceof J.Identifier) {
+                    J.Identifier id = (J.Identifier) name;
+                    if (!id.getAnnotations().isEmpty()) {
+                        name = id.withAnnotations(ListUtils.mapFirst(id.getAnnotations(), anno -> anno.withPrefix(merge(prefix(typeProjection), anno.getPrefix()))));
+                    } else {
+                        name = name.withPrefix(merge(prefix(typeProjection), name.getPrefix()));
+                    }
+                } else {
+                    name = name.withPrefix(merge(prefix(typeProjection), name.getPrefix()));
+                }
             }
         }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -537,7 +537,7 @@ class AnnotationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              val releaseDates: List<@Suppress  /*C*/ String> = emptyList()
+              val releaseDates: List< /*C0*/  @Suppress  /*C1*/ String> = emptyList()
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/PropertyTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/PropertyTest.java
@@ -86,4 +86,15 @@ class PropertyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void annotatedTypeParameter() {
+        rewriteRun(
+          kotlin(
+            """
+              val releaseDates: List</*c*/@Suppress Date> = emptyList()
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
```diff
diff --git a/openRewriteFile.kt b/openRewriteFile.kt
index f213045..e19ad9f 100644
--- a/openRewriteFile.kt
+++ b/openRewriteFile.kt
@@ -1 +1 @@
-val releaseDates: List</*c1*/@Suppress  /*c2*/ String> = emptyList()
\ No newline at end of file
+val releaseDates: List<@Suppress/*c1*/  /*c2*/ String> = emptyList()
\ No newline at end of file
```
