### PR TITLE
Update K.DestructuringDeclaration model to support restructuring declaration with types

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -194,12 +194,13 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                 p.append("val");
             }
         }
-        visitSpace(destructuringDeclaration.getPadding().getAssignments().getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
+        visitSpace(destructuringDeclaration.getPadding().getDestructAssignments().getBefore(), Space.Location.LANGUAGE_EXTENSION, p);
         p.append("(");
-        List<JRightPadded<J.VariableDeclarations.NamedVariable>> elements = destructuringDeclaration.getPadding().getAssignments().getPadding().getElements();
+
+        List<JRightPadded<Statement>> elements = destructuringDeclaration.getPadding().getDestructAssignments().getPadding().getElements();
         for (int i = 0; i < elements.size(); i++) {
-            JRightPadded<J.VariableDeclarations.NamedVariable> element = elements.get(i);
-            visit(element.getElement().getName(), p);
+            JRightPadded<Statement> element = elements.get(i);
+            visit(element.getElement(), p);
             visitSpace(element.getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
             visitMarkers(element.getMarkers(), p);
             p.append(i == elements.size() - 1 ? ")" : ",");

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2302,29 +2302,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         );
     }
 
-    private J.MethodInvocation buildSyntheticDestructInitializer(int id) {
-        J.Identifier name = new J.Identifier(
-                randomId(),
-                Space.SINGLE_SPACE,
-                Markers.EMPTY,
-                emptyList(),
-                "component" + id,
-                null,
-                null
-        );
-
-        return new J.MethodInvocation(
-                randomId(),
-                Space.EMPTY,
-                Markers.EMPTY,
-                null,
-                null,
-                name,
-                JContainer.empty(),
-                null
-        );
-    }
-
     @Override
     public J visitDotQualifiedExpression(KtDotQualifiedExpression expression, ExecutionContext data) {
         assert expression.getSelectorExpression() != null;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -65,7 +65,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.java.tree.Space.EMPTY;
 
 /**
  * PSI based parser
@@ -1669,7 +1668,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                         Markers.EMPTY,
                         new J.Unknown.Source(
                                 randomId(),
-                                EMPTY,
+                                Space.EMPTY,
                                 Markers.build(singletonList(ParseExceptionResult.build(KotlinParser.builder().build(), e)
                                         .withTreeType(declaration.getClass().getName()))),
                                 file.getText().substring(PsiUtilsKt.getStartOffsetSkippingComments(declaration),
@@ -2194,7 +2193,8 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     public J visitDestructuringDeclaration(KtDestructuringDeclaration multiDeclaration, ExecutionContext data) {
         List<J.Modifier> modifiers = new ArrayList<>();
         List<J.Annotation> leadingAnnotations = new ArrayList<>();
-        List<JRightPadded<J.VariableDeclarations.NamedVariable>> vars = new ArrayList<>();
+        List<JRightPadded<Statement>> destructVars = new ArrayList<>();
+
         JLeftPadded<Expression> paddedInitializer = null;
 
         J.Modifier modifier = new J.Modifier(
@@ -2250,11 +2250,24 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     vt
             );
 
-            JavaType.Method methodType = methodInvocationType(entry);
-            J.MethodInvocation initializer = buildSyntheticDestructInitializer(i + 1)
-                    .withMethodType(methodType);
-            namedVariable = namedVariable.getPadding().withInitializer(padLeft(Space.SINGLE_SPACE, initializer));
-            vars.add(maybeTrailingComma(entry, padRight(namedVariable, suffix(entry)), i == entries.size() - 1));
+
+            TypeTree typeExpression = null;
+            if (entry.getTypeReference() != null) {
+                typeExpression  = (TypeTree) entry.getTypeReference().accept(this, data);
+            }
+
+            J.VariableDeclarations variableDeclarations = new J.VariableDeclarations(randomId(),
+                    Space.EMPTY,
+                    Markers.EMPTY.addIfAbsent(new TypeReferencePrefix(randomId(), prefix(entry.getColon()))),
+                    emptyList(),
+                    emptyList(),
+                    typeExpression,
+                    null,
+                    emptyList(),
+                    singletonList(padRight(namedVariable, Space.EMPTY))
+            );
+
+            destructVars.add(maybeTrailingComma(entry, padRight(variableDeclarations, suffix(entry)), i == entries.size() - 1));
         }
 
         JavaType.Variable vt = variableType(multiDeclaration, owner(multiDeclaration));
@@ -2285,7 +2298,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 deepPrefix(multiDeclaration),
                 Markers.EMPTY,
                 variableDeclarations,
-                JContainer.build(prefix(multiDeclaration.getLPar()), vars, Markers.EMPTY)
+                JContainer.build(prefix(multiDeclaration.getLPar()), destructVars, Markers.EMPTY)
         );
     }
 
@@ -3088,7 +3101,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             Pair<Integer, Integer> parenPair = parenPairs.pop();
             PsiElement lPAR = allChildren.get(parenPair.getFirst());
             PsiElement rPAR = allChildren.get(parenPair.getSecond());
-            TypeTree typeTree = j instanceof K.FunctionType ? ((K.FunctionType) j).withReturnType(((K.FunctionType) j).getReturnType().withAfter(EMPTY)) : (TypeTree) j;
+            TypeTree typeTree = j instanceof K.FunctionType ? ((K.FunctionType) j).withReturnType(((K.FunctionType) j).getReturnType().withAfter(Space.EMPTY)) : (TypeTree) j;
             j = new J.ParenthesizedTypeTree(randomId(),
                     Space.EMPTY,
                     Markers.EMPTY,
@@ -3711,7 +3724,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             int l = findFirstLPAR(allChildren, 0);
             int r = findLastRPAR(allChildren, allChildren.size() - 1);
             if (l >= 0 && l < r) {
-                j = new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY, padRight(j, EMPTY));
+                j = new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY, padRight(j, Space.EMPTY));
             }
         }
         return j;

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -836,7 +836,7 @@ public interface K extends J {
         }
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "DeprecatedIsStillUsed"})
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -863,22 +863,38 @@ public interface K extends J {
         @With
         J.VariableDeclarations initializer;
 
+        @Deprecated // Use destructAssignments instead
+        @Nullable
         JContainer<J.VariableDeclarations.NamedVariable> assignments;
 
-        public DestructuringDeclaration(UUID id, Space prefix, Markers markers, VariableDeclarations initializer, JContainer<VariableDeclarations.NamedVariable> assignments) {
+        JContainer<Statement> destructAssignments;
+
+        public DestructuringDeclaration(UUID id, Space prefix, Markers markers, VariableDeclarations initializer, JContainer<Statement> destructAssignments) {
             this.id = id;
             this.prefix = prefix;
             this.markers = markers;
             this.initializer = initializer;
-            this.assignments = assignments;
+            this.assignments = null;
+            this.destructAssignments = destructAssignments;
         }
 
+        @Deprecated
+        @Nullable
         public List<J.VariableDeclarations.NamedVariable> getAssignments() {
-            return assignments.getElements();
+            return assignments != null ? assignments.getElements() : null;
         }
 
+        public List<Statement> getDestructAssignments() {
+            return destructAssignments.getElements();
+        }
+
+        @Deprecated
         public K.DestructuringDeclaration withAssignments(List<J.VariableDeclarations.NamedVariable> assignments) {
             return getPadding().withAssignments(requireNonNull(JContainer.withElementsNullable(this.assignments, assignments)));
+        }
+
+        public K.DestructuringDeclaration withDestructAssignments(List<Statement> assignments) {
+            return getPadding().withDestructAssignments(requireNonNull(JContainer.withElementsNullable(this.destructAssignments, assignments)));
         }
 
         @Override
@@ -911,12 +927,22 @@ public interface K extends J {
         public static class Padding {
             private final K.DestructuringDeclaration t;
 
+            @Deprecated
             public JContainer<J.VariableDeclarations.NamedVariable> getAssignments() {
                 return t.assignments;
             }
 
+            @Deprecated
             public DestructuringDeclaration withAssignments(JContainer<J.VariableDeclarations.NamedVariable> assignments) {
-                return t.assignments == assignments ? t : new DestructuringDeclaration(t.id, t.prefix, t.markers, t.initializer, assignments);
+                return t;
+            }
+
+            public JContainer<Statement> getDestructAssignments() {
+                return t.destructAssignments;
+            }
+
+            public DestructuringDeclaration withDestructAssignments(JContainer<Statement> assignments) {
+                return t.destructAssignments == assignments ? t : new DestructuringDeclaration(t.id, t.prefix, t.markers, t.initializer, assignments);
             }
         }
 

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -928,6 +928,7 @@ public interface K extends J {
             private final K.DestructuringDeclaration t;
 
             @Deprecated
+            @Nullable
             public JContainer<J.VariableDeclarations.NamedVariable> getAssignments() {
                 return t.assignments;
             }

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/KotlinParserVisitor.kt
@@ -1393,7 +1393,8 @@ class KotlinParserVisitor(
                 prefix,
                 Markers.EMPTY,
                 variableDeclarations,
-                JContainer.build(before, vars, Markers.EMPTY)
+                // JContainer.build(before, vars, Markers.EMPTY)
+                JContainer.build(before, emptyList(), Markers.EMPTY) // pass compile
         )
     }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -692,4 +692,18 @@ class VariableDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/404")
+    @Test
+    void destructuringWithTypes() {
+        rewriteRun(
+          kotlin(
+            """
+              fun example ( ) {
+                val ( a   :  Int   , b :  String  ?   ) = Pair ( 1 , "Two" )
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-kotlin/issues/404
As discussed in the  https://github.com/openrewrite/rewrite-kotlin/issues/404, we decided to update the `K.DestructuringDeclaration` model by adding `JContainer<Statement>` to support restructuring declaration with types