### PR TITLE
Provide more info on ClassCastExceptions.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -265,7 +265,13 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
     @Override
     public J visitCallableReferenceExpression(KtCallableReferenceExpression expression, ExecutionContext data) {
-        FirResolvedCallableReference reference = (FirResolvedCallableReference) psiElementAssociations.primary(expression.getCallableReference());
+        FirElement firElement = psiElementAssociations.primary(expression.getCallableReference());
+        FirResolvedCallableReference reference;
+        if (!(firElement instanceof FirResolvedCallableReference)) {
+            throw new UnsupportedOperationException(String.format("Unsupported callable reference: %s with code: %s", expression.getClass().getName(), expression.getText()));
+        } else {
+            reference = (FirResolvedCallableReference) psiElementAssociations.primary(expression.getCallableReference());
+        }
         JavaType.Method methodReferenceType = null;
         if (reference != null && reference.getResolvedSymbol() instanceof FirNamedFunctionSymbol) {
             methodReferenceType = psiElementAssociations.getTypeMapping().methodDeclarationType(

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1892,7 +1892,13 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     mt
             );
         } else if (type == null || type == PsiElementAssociations.ExpressionType.METHOD_INVOCATION) {
-            J.Identifier name = (J.Identifier) expression.getCalleeExpression().accept(this, data);
+            J j = expression.getCalleeExpression().accept(this, data);
+            J.Identifier name;
+            if (j instanceof J.Identifier) {
+                name = (J.Identifier) j;
+            } else {
+                throw new UnsupportedOperationException(String.format("Unexpected type: %s with code %s", j.getClass().getName(), expression.getText()));
+            }
             JContainer<Expression> typeParams = mapTypeArguments(expression.getTypeArgumentList(), data);
             JContainer<Expression> args = mapFunctionCallArguments(expression.getValueArgumentList(), expression.getValueArguments(), data);
 


### PR DESCRIPTION
Changes:

- ClassCastExceptions in KotlinTreeParserVisitor#visitCallExpression and KotlinTreeParserVisitor#visitCallableReferenceExpression will provide more info so that we may reproduce and fix the errors.

This change will help #386, #387, #405, #406, #407