### PR TITLE
Support intersection type

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -698,7 +698,28 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
     @Override
     public J visitIntersectionType(KtIntersectionType definitelyNotNullType, ExecutionContext data) {
-        throw new UnsupportedOperationException("TODO");
+        List<J.Annotation> annotations = new ArrayList<>();
+        List<JRightPadded<TypeTree>> rps = new ArrayList<>(2);
+        TypeTree left = (TypeTree) requireNonNull(definitelyNotNullType.getLeftTypeRef()).accept(this, data);
+        rps.add(padRight(left, suffix(definitelyNotNullType.getLeftTypeRef())));
+        TypeTree right = (TypeTree) requireNonNull(definitelyNotNullType.getRightTypeRef()).accept(this, data);
+        rps.add(padRight(right, Space.EMPTY));
+
+        JContainer<TypeTree> bounds = JContainer.build(
+                Space.EMPTY,
+                rps,
+                Markers.EMPTY
+        );
+
+        return new J.TypeParameter(
+                randomId(),
+                deepPrefix(definitelyNotNullType),
+                Markers.EMPTY,
+                annotations,
+                emptyList(),
+                null,
+                bounds
+        );
     }
 
     @Override
@@ -1974,6 +1995,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
         List<KtTypeProjection> ktTypeProjections = ktTypeArgumentList.getArguments();
         List<JRightPadded<Expression>> parameters = new ArrayList<>(ktTypeProjections.size());
+
         for (KtTypeProjection ktTypeProjection : ktTypeProjections) {
             parameters.add(padRight(convertToExpression(ktTypeProjection.accept(this, data)), suffix(ktTypeProjection)));
         }

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
@@ -404,4 +404,19 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/442")
+    @Test
+    void intersectionType() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.util.*
+
+              @Suppress("UNUSED_PARAMETER")
+              fun <T : Any?> test(n: Optional <  T   &    Any > = Optional.empty<T>()) {}
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-kotlin/issues/442
To support the intersection type (like `T   &    Any` below),  it can be parsed to a `J.TypeParameter`, and this requires `rewrite` model update https://github.com/openrewrite/rewrite/pull/3718.

```kotlin
              import java.util.*
              @Suppress("UNUSED_PARAMETER")
              fun <T : Any?> test(n: Optional <  T   &    Any > = Optional.empty<T>()) {}
```

Alternatively, we can parse `T   &    Any` to a `K.Binary` instead of a `J.TypeParameter` with a new binary type.