### PR TITLE
Fix extension property printing

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -365,20 +365,6 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
                 visitRightPadded(property.getPadding().getReceiver(), p);
                 p.append(".");
             }
-
-            if (property.getSetter() != null &&
-                    !property.getSetter().getParameters().isEmpty() &&
-                    property.getSetter().getParameters().get(0) instanceof J.VariableDeclarations) {
-                visit(((J.VariableDeclarations) property.getSetter().getParameters().get(0)).getTypeExpression(), p);
-                delegate.visitSpace(property.getSetter().getPadding().getParameters().getPadding().getElements().get(0).getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
-                p.append(".");
-            } else if (property.getGetter() != null &&
-                    !property.getGetter().getParameters().isEmpty() &&
-                    property.getGetter().getParameters().get(0) instanceof J.VariableDeclarations) {
-                visit(((J.VariableDeclarations) property.getGetter().getParameters().get(0)).getTypeExpression(), p);
-                delegate.visitSpace(property.getGetter().getPadding().getParameters().getPadding().getElements().get(0).getAfter(), Space.Location.LANGUAGE_EXTENSION, p);
-                p.append(".");
-            }
         }
 
         if (!vd.getVariables().isEmpty()) {

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -734,4 +734,25 @@ class VariableDeclarationTest implements RewriteTest {
           )
         );
     }
+
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/447")
+    @Test
+    void extensionProperty() {
+        rewriteRun(
+          kotlin(
+            """
+              class A {
+                  var internalProperty = "x"
+              }
+
+              var A .  property   : String
+                  get() = ""
+                  set(value) {
+                      internalProperty = value
+                  }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-kotlin/issues/447
there are some codes in the Kotlin printer when printing a `K.Property` I do not quite understand the purpose, and I found that removing that part of the code can solve this problem without breaking anything, I think we are safe to delete them but want to have another eye to also take a look.