### PR TITLE
Allow unknown parameterized types

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -3147,7 +3147,9 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             JContainer<Expression> args = mapTypeArguments(type.getTypeArgumentList(), data);
 
             JavaType javaType = type(type);
-            if (!(javaType instanceof JavaType.Parameterized)) {
+            if (javaType instanceof JavaType.Unknown) {
+                javaType = new JavaType.Parameterized(null, JavaType.Unknown.getInstance(), null);
+            } else if (!(javaType instanceof JavaType.Parameterized)) {
                 throw new UnsupportedOperationException("java type is not a Parameterized: " + type.getText());
             }
 


### PR DESCRIPTION
Ideally, the source code does not contain any unresolved types. But it would typically still be preferable if the parser is able to produce an LST with missing type attribution rather than no LST at all.
