### PR TITLE
Don't throw exception from `K.Constructor#withType()`

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -656,7 +656,7 @@ public interface K extends J {
 
         @Override
         public Constructor withType(@Nullable JavaType type) {
-            throw new UnsupportedOperationException("To change the return type of this constructor, use withMethodType(..)");
+            return this; // type must be changed on method declaration
         }
 
         @Override

--- a/src/test/java/org/openrewrite/kotlin/ChangePackageTest.java
+++ b/src/test/java/org/openrewrite/kotlin/ChangePackageTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.kotlin;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.PathUtils;
@@ -169,7 +168,6 @@ class ChangePackageTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/433")
     @Test
     void changePackageSecondaryConstructor() {

--- a/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -375,7 +375,6 @@ class ChangeTypeTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/433")
     @Test
     void changeImportSecondaryConstructor() {


### PR DESCRIPTION
As the constructor's type must be changed through `K.Constructor#methodDeclaration`, the `withType()` method is now simply a no-op (which is also something we do in some other places).

Fixes: #433
