### PR TITLE
Fixed types on TypeParameter names.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1303,6 +1303,8 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     public J visitTypeConstraint(KtTypeConstraint constraint, ExecutionContext data) {
         List<J.Annotation> annotations = new ArrayList<>();
         J.Identifier typeParamName = (J.Identifier) requireNonNull(constraint.getSubjectTypeParameterName()).accept(this, data);
+        PsiElement ref = PsiTreeUtil.getChildOfType(constraint, KtTypeReference.class);
+        typeParamName = typeParamName.withType(psiElementAssociations.type(ref, owner(constraint)));
         TypeTree typeTree = (TypeTree) requireNonNull(constraint.getBoundTypeReference()).accept(this, data);
 
         return new J.TypeParameter(


### PR DESCRIPTION
Changes:
- The type on TypeParameter names matched the bounded type.
- Updated `PsiElementAssociations#fir()` to return the correctly associated fir.
    - The method filters for real PSI sources and assumes the first element is associated with the PSI. While looking at the type associations, I noticed that the first element is not always correct. The changes add mappings to ensure the correct FIR is returned for a PSI.
- Added a filter in the `PsiElementAssociations#initialize` to prevent `FirUserTypeRef` from being visited and removed the `is FirUserTypeRef` condition from the `primary(filter)`.

fixes #461