### PR TITLE
Added detection of annotation constructors to create J.Annotation in visitCallExpression.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -467,7 +467,8 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         @Override
         public J visitAnnotation(J.Annotation annotation, PrintOutputCapture<P> p) {
             beforeSyntax(annotation, Space.Location.ANNOTATION_PREFIX, p);
-            boolean isKModifier = annotation.getMarkers().findFirst(Modifier.class).isPresent();
+            // Modifier is used for backwards compatibility.
+            boolean isKModifier = annotation.getMarkers().findFirst(Modifier.class).isPresent() || annotation.getMarkers().findFirst(AnnotationConstructor.class).isPresent();
             if (!isKModifier) {
                 p.append("@");
             }

--- a/src/main/java/org/openrewrite/kotlin/marker/AnnotationConstructor.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/AnnotationConstructor.java
@@ -21,13 +21,23 @@ import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
-@Deprecated
+/**
+ * The construction of new annotations does not require the `@` character.
+ * Example:
+ *  @Tags(
+ *      value = [
+ *          Tag(value = "Sample01"),
+ *          Tag(value = "Sample02"),
+ *      ]
+ *  )
+ */
+@SuppressWarnings("JavadocDeclaration")
 @Value
 @With
-public class Modifier implements Marker {
+public class AnnotationConstructor implements Marker {
     UUID id;
 
-    public Modifier(UUID id) {
+    public AnnotationConstructor(UUID id) {
         this.id = id;
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/ChangeAnnotationAttributeNameTest.java
+++ b/src/test/java/org/openrewrite/kotlin/ChangeAnnotationAttributeNameTest.java
@@ -16,19 +16,15 @@
 package org.openrewrite.kotlin;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.java.ChangeAnnotationAttributeName;
-import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class ChangeAnnotationAttributeNameTest implements RewriteTest {
 
-    @ExpectedToFail
     @Test
-    public void runKotlin() {
+    public void changeAnnotationAttributes() {
         rewriteRun(
           spec -> spec.recipe(new ChangeAnnotationAttributeName(
               "org.junit.jupiter.api.Tag",
@@ -39,12 +35,12 @@ class ChangeAnnotationAttributeNameTest implements RewriteTest {
           kotlin(
             """
               package sample
-               
+              
               import org.junit.jupiter.api.Tag
               import org.junit.jupiter.api.Tags
-               
+              
               class SampleTest {
-               
+              
                   @Tags(
                       value = [
                           Tag(value = "Sample01"),
@@ -57,12 +53,12 @@ class ChangeAnnotationAttributeNameTest implements RewriteTest {
               """,
             """
               package sample
-               
+              
               import org.junit.jupiter.api.Tag
-               import org.junit.jupiter.api.Tags
-               
+              import org.junit.jupiter.api.Tags
+              
               class SampleTest {
-               
+              
                   @Tags(
                       value = [
                           Tag(newValue = "Sample01"),
@@ -73,47 +69,6 @@ class ChangeAnnotationAttributeNameTest implements RewriteTest {
                   }
               }
               """
-          )
-        );
-    }
-
-    // working well
-    @Test
-    public void runJava() {
-        rewriteRun(
-          spec -> spec.recipe(new ChangeAnnotationAttributeName(
-              "org.junit.jupiter.api.Tag",
-              "value",
-              "newValue"
-            ))
-            .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
-          java(
-            """
-                    package sample;
-                                                    
-                    import org.junit.jupiter.api.Tag;
-                    import org.junit.jupiter.api.Tags;
-                                                    
-                    public class SampleJavaTest {
-                                                    
-                        @Tags(value = {@Tag(value = "Sample"), @Tag(value = "Sample03")})
-                        public void runTest() {
-                        }
-                    }
-                    """,
-            """
-                    package sample;
-                                                    
-                    import org.junit.jupiter.api.Tag;
-                    import org.junit.jupiter.api.Tags;
-                                                    
-                    public class SampleJavaTest {
-                                                    
-                        @Tags(value = {@Tag(newValue = "Sample"), @Tag(newValue = "Sample03")})
-                        public void runTest() {
-                        }
-                    }
-                    """
           )
         );
     }


### PR DESCRIPTION
Changes:

- `ChangeAnnotationAttributeName` will properly change attributes of J.Annotations.
- J.Annotation is created when used as a value (when type attribution is available) in visitCallExpression.
- AnnotationConstructor marker and deprecated `Modifier` marker. Replaced use of `Modifier` with `AnnotationConstructor`.

fixes #475