### PR TITLE
Map types in `PsiElementAssociations`

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -79,9 +79,14 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
             private fun visitType(firType: ConeTypeProjection, psiType: KtTypeReference) {
                 if (firType is ConeClassLikeType) {
                     val psiTypeArguments = psiType.typeElement!!.typeArgumentsAsTypes
+                    if (psiTypeArguments.size != firType.typeArguments.size) {
+                        // TODO check why this is happening
+                        return
+                    }
                     for ((index, typeArgument) in firType.typeArguments.withIndex()) {
-                        visitType(typeArgument, psiTypeArguments[index])
-                        typeMap[psiTypeArguments[index]] = typeArgument
+                        val psiTypeArgument = psiTypeArguments[index] ?: continue
+                        visitType(typeArgument, psiTypeArgument)
+                        typeMap[psiTypeArgument] = typeArgument
                     }
                 }
             }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.Parser;
@@ -934,6 +935,38 @@ public class KotlinTypeMappingTest {
                       }
                   }
                   """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/473")
+        @ParameterizedTest
+        @ValueSource(strings = {
+          // Multiple levels of parameterized types
+          "val map: Map<Map<Int, Int>, Map<Int?, Int?>> = mapOf()",
+          // ConeTypeParameterType
+          "val <T : Any> Collection<T>.nullable: Collection<T?>"
+        })
+        void typeParameters(String value) {
+            rewriteRun(
+              kotlin("%s".formatted(value),
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean found = new AtomicBoolean(false);
+                    new KotlinIsoVisitor<Integer>() {
+                        @Override
+                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                            if ("Int".equals(identifier.getSimpleName())) {
+                                assertThat(identifier.getType().toString()).isEqualTo("kotlin.Int");
+                                found.set(true);
+                            } else if ("T".equals(identifier.getSimpleName())) {
+                                assertThat(identifier.getType().toString()).isEqualTo("Generic{T extends kotlin.Any}");
+                                found.set(true);
+                            }
+                            return super.visitIdentifier(identifier, integer);
+                        }
+                    }.visit(cu, 0);
+                    assertThat(found.get()).isTrue();
+                })
               )
             );
         }


### PR DESCRIPTION
The types themselves are not FIR elements and thus not visited by the visitor used to populate the associations map. However, these can be visited separately, so that they later can be retrieved using `type()`.

fixes #473