### PR TITLE
Deprecate `IsNullable` marker and use `K.Unary` instead

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -422,9 +422,6 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         if (m instanceof AnnotationUseSite) {
             AnnotationUseSite acs = (AnnotationUseSite) marker;
             m = acs.withPrefix(visitSpace(acs.getPrefix(), KSpace.Location.ANNOTATION_CALL_SITE_PREFIX, p));
-        } else if (marker instanceof IsNullable) {
-            IsNullable isn = (IsNullable) marker;
-            m = isn.withPrefix(visitSpace(isn.getPrefix(), KSpace.Location.IS_NULLABLE_PREFIX, p));
         } else if (marker instanceof IsNullSafe) {
             IsNullSafe ins = (IsNullSafe) marker;
             m = ins.withPrefix(visitSpace(ins.getPrefix(), KSpace.Location.IS_NULLABLE_PREFIX, p));

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -39,7 +39,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 
-@SuppressWarnings("SwitchStatementWithTooFewBranches")
 public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     private final KotlinJavaPrinter<P> delegate;
 
@@ -417,10 +416,16 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         beforeSyntax(unary, Space.Location.UNARY_PREFIX, p);
         switch (unary.getOperator()) {
             case NotNull:
-            default:
                 visit(unary.getExpression(), p);
                 visitSpace(unary.getPadding().getOperator().getBefore(), Space.Location.UNARY_OPERATOR, p);
                 p.append("!!");
+                break;
+            case Nullable:
+                visit(unary.getExpression(), p);
+                visitSpace(unary.getPadding().getOperator().getBefore(), Space.Location.UNARY_OPERATOR, p);
+                p.append("?");
+                break;
+            default:
                 break;
         }
         afterSyntax(unary, p);

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -218,13 +218,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
     @Override
     public J visitFunctionType(K.FunctionType functionType, PrintOutputCapture<P> p) {
-        boolean nullable = functionType.getMarkers().findFirst(IsNullable.class).isPresent();
-
         beforeSyntax(functionType, KSpace.Location.FUNCTION_TYPE_PREFIX, p);
-        if (nullable) {
-            p.append("(");
-        }
-
         visit(functionType.getLeadingAnnotations(), p);
         for (J.Modifier modifier : functionType.getModifiers()) {
             delegate.visitModifier(modifier, p);
@@ -239,9 +233,6 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
         p.append("->");
 
         visitRightPadded(functionType.getReturnType(), p);
-        if (nullable) {
-            p.append(")");
-        }
         afterSyntax(functionType, p);
         return functionType;
     }
@@ -1311,7 +1302,6 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
         @Override
         protected void afterSyntax(J j, PrintOutputCapture<P> p) {
-            kotlinPrinter.trailingMarkers(j.getMarkers(), p);
             super.afterSyntax(j, p);
         }
     }
@@ -1327,15 +1317,6 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             throw new UnsupportedOperationException("Class kind is not supported: " + classDecl.getKind());
         }
         return kind;
-    }
-
-    private void trailingMarkers(Markers markers, PrintOutputCapture<P> p) {
-        for (Marker marker : markers.getMarkers()) {
-            if (marker instanceof IsNullable) {
-                KotlinPrinter.this.visitSpace(((IsNullable) marker).getPrefix(), KSpace.Location.TYPE_REFERENCE_PREFIX, p);
-                p.append("?");
-            }
-        }
     }
 
     @Override
@@ -1419,7 +1400,6 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     }
 
     private void afterSyntax(J j, PrintOutputCapture<P> p) {
-        trailingMarkers(j.getMarkers(), p);
         afterSyntax(j.getMarkers(), p);
     }
 

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -68,7 +68,7 @@ import static org.openrewrite.Tree.randomId;
 /**
  * PSI based parser
  */
-@SuppressWarnings("ConstantValue")
+@SuppressWarnings({"ConstantValue", "DataFlowIssue", "SameParameterValue", "unused"})
 public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     private final KotlinSource kotlinSource;
     private final PsiElementAssociations psiElementAssociations;
@@ -815,10 +815,12 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             typeTree = ((K.FunctionType) typeTree).withModifiers(modifiers).withLeadingAnnotations(leadingAnnotations);
         }
 
-        return typeTree.withPrefix(merge(deepPrefix(nullableType), typeTree.getPrefix()))
-                .withMarkers(typeTree.getMarkers().addIfAbsent(new IsNullable(randomId(),
-                        prefix((PsiElement) nullableType.getQuestionMarkNode())
-                )));
+        return new K.Unary(randomId(),
+                merge(deepPrefix(nullableType), typeTree.getPrefix()),
+                Markers.EMPTY,
+                padLeft(prefix(findFirstChild(nullableType, c -> c.getNode().getElementType() == KtTokens.QUEST)), K.Unary.Type.Nullable),
+                convertToExpression(typeTree),
+                typeTree.getType());
     }
 
     @Override

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -298,7 +298,12 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             Expression receiverExp = convertToExpression(expression.getReceiverExpression().accept(this, data));
             if (expression.getHasQuestionMarks()) {
                 PsiElement questionMark = PsiTreeUtil.findSiblingForward(expression.getFirstChild(), KtTokens.QUEST, null);
-                receiverExp = receiverExp.withMarkers(receiverExp.getMarkers().addIfAbsent(new IsNullable(randomId(), prefix(questionMark))));
+                receiverExp = new K.Unary(randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        padLeft(prefix(questionMark), K.Unary.Type.Nullable),
+                        convertToExpression(receiverExp),
+                        receiverExp.getType());
             }
             receiver = padRight(receiverExp, prefix(expression.findColonColon()));
         }

--- a/src/main/java/org/openrewrite/kotlin/marker/IsNullable.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/IsNullable.java
@@ -22,6 +22,7 @@ import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
+@Deprecated
 @Value
 @With
 public class IsNullable implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -2234,11 +2234,13 @@ public interface K extends J {
 
         @SuppressWarnings("SwitchStatementWithTooFewBranches")
         public enum Type {
-            NotNull;
+            NotNull,
+            Nullable;
 
             public boolean isModifying() {
                 switch (this) {
                     case NotNull:
+                    case Nullable:
                     default:
                         return false;
                 }

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -2174,7 +2174,7 @@ public interface K extends J {
     @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
     @RequiredArgsConstructor
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    final class Unary implements K, Statement, Expression, TypedTree {
+    final class Unary implements K, Statement, Expression, TypeTree {
         @Nullable
         @NonFinal
         transient WeakReference<K.Unary.Padding> padding;

--- a/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
@@ -937,7 +937,7 @@ class SpacesTest implements RewriteTest {
               """,
             """
               class A {
-                  fun method ( ) /*TYPE_REFERENCE_PREFIX*/: Int /*IS_NULLABLE_PREFIX*/? {
+                  fun method ( ) /*TYPE_REFERENCE_PREFIX*/: Int /*UNARY_OPERATOR*/? {
                       return 1
                   }
               }


### PR DESCRIPTION
Use `K.Unary` to present `nullableType` instead of `IsNullable` marker

To support this, we need to change `K.Unary` extends `TypeTree` instead of `TypedTree`

part of https://github.com/openrewrite/rewrite-kotlin/issues/477