### PR TITLE
Set the type on `J.Identifier` to null if it resolves to `J.Unknown`.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -3430,7 +3430,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 Markers.EMPTY,
                 emptyList(),
                 name,
-                type,
+                type instanceof JavaType.Unknown ? null : type,
                 fieldType
         );
     }

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -863,6 +863,27 @@ public class KotlinTypeMappingTest {
             );
         }
 
+        @Test
+        void unknownIdentifier() {
+            rewriteRun(
+              kotlin(
+                //language=none
+                "class A : RemoteStub",
+                    spec -> spec.afterRecipe(cu -> {
+                        new KotlinIsoVisitor<Integer>() {
+                            @Override
+                            public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                                if ("RemoteStub".equals(identifier.getSimpleName())) {
+                                    assertThat(identifier.getType()).isNull();
+                                }
+                                return super.visitIdentifier(identifier, integer);
+                            }
+                        }.visit(cu, 0);
+                })
+              )
+            );
+        }
+
         @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/461")
         @Test
         void multipleBounds() {


### PR DESCRIPTION
Changes:

- J.Identifier will have a null type if type mapping resolves to `J.Unknown`.

fixes #484