### PR TITLE
Deprecate the `prefix` field of `IsNullSafe` marker since it's uncessery

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -425,9 +425,6 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         } else if (marker instanceof IsNullable) {
             IsNullable isn = (IsNullable) marker;
             m = isn.withPrefix(visitSpace(isn.getPrefix(), KSpace.Location.IS_NULLABLE_PREFIX, p));
-        } else if (marker instanceof IsNullSafe) {
-            IsNullSafe ins = (IsNullSafe) marker;
-            m = ins.withPrefix(visitSpace(ins.getPrefix(), KSpace.Location.IS_NULLABLE_PREFIX, p));
         } else if (marker instanceof TypeReferencePrefix) {
             TypeReferencePrefix tr = (TypeReferencePrefix) marker;
             m = tr.withPrefix(visitSpace(tr.getPrefix(), KSpace.Location.TYPE_REFERENCE_PREFIX, p));

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1086,8 +1086,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     @Override
     public J visitSafeQualifiedExpression(KtSafeQualifiedExpression expression, ExecutionContext data) {
         J j = visitQualifiedExpression(expression, data);
-        ASTNode safeAccess = expression.getNode().findChildByType(KtTokens.SAFE_ACCESS);
-        return j.withMarkers(j.getMarkers().addIfAbsent(new IsNullSafe(randomId(), safeAccess != null ? prefix(safeAccess.getPsi()) : Space.EMPTY)));
+        return j.withMarkers(j.getMarkers().addIfAbsent(new IsNullSafe(randomId(), Space.EMPTY)));
     }
 
     @Override

--- a/src/main/java/org/openrewrite/kotlin/marker/Elvis.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/Elvis.java
@@ -21,6 +21,7 @@ import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
+@Deprecated
 @Value
 @With
 public class Elvis implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/marker/IsNullSafe.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/IsNullSafe.java
@@ -26,10 +26,12 @@ import java.util.UUID;
 @With
 public class IsNullSafe implements Marker {
     UUID id;
+
+    @Deprecated
     Space prefix;
 
     public IsNullSafe(UUID id, Space prefix) {
         this.id = id;
-        this.prefix = prefix;
+        this.prefix = Space.EMPTY;
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/format/TabsAndIndentsTest.java
+++ b/src/test/java/org/openrewrite/kotlin/format/TabsAndIndentsTest.java
@@ -2250,13 +2250,17 @@ class TabsAndIndentsTest implements RewriteTest {
             """
               fun f(): String? {
                   val values = (listOf("") as List<String>?)
-                              ?.map { it }
+                      ?.map { it }
                           ?: return null
                   return values.joinToString("")
               }
               """
           )
         );
+    }
+
+    @Test
+    void ternaryIndentation2() {
         rewriteRun(
           wrappingAndBraces(style -> style.withElvisExpressions(style.getElvisExpressions().withUseContinuationIndent(true))),
           kotlin(
@@ -2264,14 +2268,14 @@ class TabsAndIndentsTest implements RewriteTest {
               fun f(): String? {
                   val values = (listOf("") as List<String>?)
                       ?.map { it }
-                          ?: return null
+                      ?: return null
                   return values.joinToString("")
               }
               """,
             """
               fun f(): String? {
                   val values = (listOf("") as List<String>?)
-                              ?.map { it }
+                      ?.map { it }
                           ?: return null
                   return values.joinToString("")
               }

--- a/src/test/java/org/openrewrite/kotlin/tree/AnonymousFunctionTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnonymousFunctionTest.java
@@ -52,7 +52,7 @@ class AnonymousFunctionTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              val filter = null?.let { _ ->
+              val filter = null   ?. let { _ ->
                   { false
                   }
               }


### PR DESCRIPTION
There are total 3 usage scenarios of `IsNullSafe` marker.
1. `J.FieldAccess`, example: `test   ?. property`, the space before `?.` is handled by leftPadded
2. `J.MethodInvocation`, example: 
```
              val filter = null   ?. let { _ ->
                  { false
                  }
              }
```
   the space before `?.` is handled by suffix of the select (RightPadded)

3. `J.TypeCast`, example `val map = mapOf(Pair("one", 1))   as? Map<*, *>`, the space before  `?.` is handled by the prefix of `J.TypeCast.clazz`

so the prefix in this marker is not necessary, we can just deprecate the `prefix` field and keep the marker there.

this PR is related to https://github.com/openrewrite/rewrite-kotlin/issues/477