### PR TITLE
Fix quoted identifier name.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -23,6 +23,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaPrinter;
 import org.openrewrite.java.marker.ImplicitReturn;
 import org.openrewrite.java.marker.OmitParentheses;
+import org.openrewrite.java.marker.Quoted;
 import org.openrewrite.java.marker.TrailingComma;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinVisitor;
@@ -751,7 +752,14 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             visit(ident.getAnnotations(), p);
             beforeSyntax(ident, Space.Location.IDENTIFIER_PREFIX, p);
             visitSpace(Space.EMPTY, Space.Location.ANNOTATIONS, p);
+            boolean isQuoted = ident.getMarkers().findFirst(Quoted.class).isPresent();
+            if (isQuoted) {
+                p.append("`");
+            }
             p.append(ident.getSimpleName());
+            if (isQuoted) {
+                p.append("`");
+            }
             afterSyntax(ident, p);
             return ident;
         }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -46,6 +46,7 @@ import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.marker.ImplicitReturn;
 import org.openrewrite.java.marker.OmitParentheses;
+import org.openrewrite.java.marker.Quoted;
 import org.openrewrite.java.marker.TrailingComma;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinParser;
@@ -3452,12 +3453,18 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     private J.Identifier createIdentifier(String name, Space prefix,
                                           @Nullable JavaType type,
                                           @Nullable JavaType.Variable fieldType) {
+        Markers markers = Markers.EMPTY;
+        String updated = name;
+        if (name.startsWith("`")) {
+            updated = updated.substring(1, updated.length() - 1);
+            markers = markers.addIfAbsent(new Quoted(randomId()));
+        }
         return new J.Identifier(
                 randomId(),
                 prefix,
-                Markers.EMPTY,
+                markers,
                 emptyList(),
-                name,
+                updated,
                 type instanceof JavaType.Unknown ? null : type,
                 fieldType
         );


### PR DESCRIPTION
Changes:

- The name of identifiers escaped with back-ticks will match the field name.
- `Quoted` marker preserves the escapes.

fixes #479