### PR TITLE
Match type of unused variable name.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -57,6 +57,7 @@ import org.openrewrite.java.tree.JavaType
 import org.openrewrite.java.tree.JavaType.*
 import org.openrewrite.java.tree.TypeUtils
 import org.openrewrite.kotlin.KotlinTypeSignatureBuilder.Companion.convertClassIdToFqn
+import org.openrewrite.kotlin.KotlinTypeSignatureBuilder.Companion.variableName
 import kotlin.collections.ArrayList
 
 @Suppress("DuplicatedCode")
@@ -827,7 +828,7 @@ class KotlinTypeMapping(
         val vt = Variable(
             null,
             mapToFlagsBitmap(variable.visibility, variable.modality),
-            variable.name.asString(),
+            variableName(variable.name.asString()),
             null, null, null
         )
         typeCache.put(signature, vt)
@@ -1154,7 +1155,7 @@ class KotlinTypeMapping(
         val variable = Variable(
             null,
             convertToFlagsBitMap(javaField.visibility, javaField.isStatic, javaField.isFinal, javaField.isAbstract),
-            javaField.name.asString(),
+            variableName(javaField.name.asString()),
             null, null, null
         )
         typeCache.put(signature, variable)

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -523,7 +523,7 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
             else -> fileSignature(firFile)
         }
         sig.append(owner)
-        sig.append("{name=${property.name.asString()}")
+        sig.append("{name=${variableName(property.name.asString())}")
         sig.append(",type=${signature(property.returnTypeRef)}}")
         return sig.toString()
     }
@@ -661,7 +661,7 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
             owner = owner.substring(0, owner.indexOf('<'))
         }
         sig.append(owner)
-        sig.append("{name=${javaField.name.asString()}")
+        sig.append("{name=${variableName(javaField.name.asString())}")
         sig.append(",type=${signature(javaField.type)}}")
         return sig.toString()
     }
@@ -686,6 +686,13 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
                 .replace("/", ".")
                 .replace("?", "")
             return if (cleanedFqn.startsWith(".")) cleanedFqn.substring(1) else cleanedFqn
+        }
+
+        fun variableName(name: String): String {
+            return when (name) {
+                "<unused var>" -> "_"
+                else -> name
+            }
         }
     }
 }


### PR DESCRIPTION
Changes:

- VariableType name of an unused var `_` will match the source code.

fixes #483