### PR TITLE
Fix the method name on method types of property access accessors.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -57,6 +57,7 @@ import org.openrewrite.java.tree.JavaType
 import org.openrewrite.java.tree.JavaType.*
 import org.openrewrite.java.tree.TypeUtils
 import org.openrewrite.kotlin.KotlinTypeSignatureBuilder.Companion.convertClassIdToFqn
+import org.openrewrite.kotlin.KotlinTypeSignatureBuilder.Companion.methodName
 import org.openrewrite.kotlin.KotlinTypeSignatureBuilder.Companion.variableName
 import kotlin.collections.ArrayList
 
@@ -497,7 +498,7 @@ class KotlinTypeMapping(
             null,
             mapToFlagsBitmap(function.visibility, function.modality),
             null,
-            if (function.symbol is FirConstructorSymbol) "<constructor>" else function.symbol.name.asString(),
+            if (function.symbol is FirConstructorSymbol) "<constructor>" else methodName(function),
             null,
             paramNames,
             null, null, null,

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -333,7 +333,7 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
         val sig = StringBuilder(clazz)
         when {
             function.symbol is FirConstructorSymbol -> sig.append("{name=<constructor>,return=${signature(function.returnTypeRef)}")
-            else -> sig.append("{name=${function.symbol.name.asString()},return=${signature(function.returnTypeRef)}")
+            else -> sig.append("{name=${methodName(function)},return=${signature(function.returnTypeRef)}")
         }
         sig.append(",parameters=${methodArgumentSignature(function)}}")
         return sig.toString()
@@ -686,6 +686,17 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
                 .replace("/", ".")
                 .replace("?", "")
             return if (cleanedFqn.startsWith(".")) cleanedFqn.substring(1) else cleanedFqn
+        }
+
+        fun methodName(function: FirFunction): String {
+            return when (function) {
+                is FirPropertyAccessor -> when {
+                    function.isGetter -> "get"
+                    function.isSetter -> "set"
+                    else -> function.symbol.name.asString()
+                }
+                else -> function.symbol.name.asString()
+            }
         }
 
         fun variableName(name: String): String {

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeSignatureBuilderTest.java
@@ -202,13 +202,13 @@ public class KotlinTypeSignatureBuilderTest {
     @Test
     void gettableField() {
         assertThat(fieldPropertyGetterSignature("field"))
-                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=accessor,return=kotlin.Int,parameters=[]}");
+                .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=get,return=kotlin.Int,parameters=[]}");
     }
 
     @Test
     void settableField() {
         assertThat(fieldPropertySetterSignature("field"))
-          .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=accessor,return=kotlin.Unit,parameters=[kotlin.Int]}");
+          .isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat{name=set,return=kotlin.Unit,parameters=[kotlin.Int]}");
     }
 
     @Test


### PR DESCRIPTION
Changes:

- The MethodType#name will match the name of property accessors.
    - The FIR PropertyAccessor has a name of `accessor`, which does not match the source code.

fixes #481