### PR TITLE
Preserve back ticks in imports during parsing.

### DIFF
--- a/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.kotlin;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.java.ChangeType;
@@ -82,6 +83,34 @@ class ChangeTypeTest implements RewriteTest {
               
               class A {
                   val type : `Target` = Target()
+              }
+              """
+          )
+        );
+    }
+
+    @ExpectedToFail("Add import does not preserve escapes.")
+    @Test
+    void changeEscapedImport() {
+        rewriteRun(
+          kotlin(
+            """
+              package a.b
+              class Original
+              """),
+          kotlin(
+            """
+              import a.b.`Original`
+              
+              class A {
+                  val type : Original = Original()
+              }
+              """,
+            """
+              import x.y.`Target`
+              
+              class A {
+                  val type : Target = Target()
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -1041,5 +1041,37 @@ public class KotlinTypeMappingTest {
               )
             );
         }
+
+        @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/493")
+        @Test
+        void escapedImport() {
+            //noinspection RemoveRedundantBackticks
+            rewriteRun(
+              kotlin(
+                """
+                  @file:Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+                  import `java`.`util`.`List`
+                  """,
+                spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean found = new AtomicBoolean(false);
+                    new KotlinIsoVisitor<Integer>() {
+                        @Override
+                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                            assertThat(identifier.getSimpleName().startsWith("`")).isFalse();
+                            return super.visitIdentifier(identifier, integer);
+                        }
+
+                        @Override
+                        public J.Import visitImport(J.Import _import, Integer integer) {
+                            assertThat(_import.getQualid().getType().toString()).isEqualTo("java.util.List");
+                            found.set(true);
+                            return super.visitImport(_import, integer);
+                        }
+                    }.visit(cu, 0);
+                    assertThat(found.get()).isTrue();
+                })
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
Changes:
- Type on imports and aliases is set correctly.
- Escaped identifiers will match the source names; the escapes are preserved with the `Quote` marker.

fixes #493