### PR TITLE
Added support for imports with escaped names.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/AddImport.java
+++ b/src/main/java/org/openrewrite/kotlin/AddImport.java
@@ -143,7 +143,7 @@ public class AddImport<P> extends KotlinIsoVisitor<P> {
                     Markers.EMPTY,
                     new JLeftPadded<>(Space.EMPTY, member != null, Markers.EMPTY),
                     TypeTree.build(fullyQualifiedName +
-                                   (member == null ? "" : "." + member)).withPrefix(Space.SINGLE_SPACE),
+                                   (member == null ? "" : "." + member), '`').withPrefix(Space.SINGLE_SPACE),
                     alias != null ? new JLeftPadded<>(
                             Space.SINGLE_SPACE,
                             new J.Identifier(

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -49,6 +49,7 @@ import org.jetbrains.kotlin.fir.types.jvm.FirJavaTypeRef
 import org.jetbrains.kotlin.load.java.structure.*
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.*
 import org.jetbrains.kotlin.load.kotlin.JvmPackagePartSource
+import org.jetbrains.kotlin.name.isOneSegmentFQN
 import org.jetbrains.kotlin.resolve.jvm.JvmClassName
 import org.jetbrains.kotlin.types.ConstantValueKind
 import org.jetbrains.kotlin.types.Variance
@@ -204,8 +205,12 @@ class KotlinTypeMapping(
 
     @OptIn(SymbolInternals::class)
     private fun resolveImport(type: FirImport, signature: String): JavaType? {
+        if (type.importedFqName == null || type.importedFqName!!.isOneSegmentFQN()) {
+            return null
+        }
+
         // If the symbol is not resolvable we return a NEW ShallowClass to prevent caching on a potentially resolvable class type.
-        val sym = type.importedFqName?.topLevelClassAsmType()?.classId?.toSymbol(firSession) ?: return ShallowClass.build(signature)
+        val sym = type.importedFqName!!.topLevelClassAsmType().classId.toSymbol(firSession) ?: return ShallowClass.build(signature)
         return type(sym.fir, signature)
     }
 

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -180,7 +180,7 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
             }
 
             is FirResolvedImport -> {
-                signature(type.importedFqName)
+                resolveImport(type)
             }
 
             is FqName -> {
@@ -437,6 +437,10 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
             }
         }
         return genericArgumentTypes.toString()
+    }
+
+    private fun resolveImport(type: FirResolvedImport): String {
+        return signature(type.importedFqName) + (if (type.isAllUnder) ".*" else "")
     }
 
     @OptIn(SymbolInternals::class)

--- a/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -88,6 +88,34 @@ class ChangeTypeTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/493")
+    @Test
+    void changeEscapedImport() {
+        rewriteRun(
+          kotlin(
+            """
+              package a.b
+              class Original
+              """),
+          kotlin(
+            """
+              import a.b.`Original`
+              
+              class A {
+                  val type : Original = Original()
+              }
+              """,
+            """
+              import x.y.Target
+              
+              class A {
+                  val type : Target = Target()
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void changeImportAlias() {
         rewriteRun(


### PR DESCRIPTION
Changes:

- Imports are created with escaped FQNs using Quote markers in `KotlinTreeParserVisitor`.
- Imports will have the resolved types rather than a shallow class.
- AddImport supports escaped FQNs.
- ChangeType will correctly update types with escaped names.

fixes https://github.com/openrewrite/rewrite-kotlin/issues/493