### PR TITLE
Fixed type on J.MemberReference created in KotlinTreeParserVisitor#visitCallableReferenceExpression.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -311,7 +311,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 receiver,
                 null,
                 padLeft(prefix(expression.getLastChild()), expression.getCallableReference().accept(this, data).withPrefix(Space.EMPTY)),
-                type(expression.getCallableReference()),
+                type(expression),
                 methodReferenceType,
                 fieldReferenceType
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/MemberReferenceTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MemberReferenceTest.java
@@ -21,7 +21,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
-class MethodReferenceTest implements RewriteTest {
+class MemberReferenceTest implements RewriteTest {
 
     @Test
     void fieldReference() {


### PR DESCRIPTION
Changes:

- MemberReferences will contain the correct type.
fixes #485