### PR TITLE
Get rid of `TypeReferencePrefix` marker from `J.VariableDeclarations`

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/RenameTypeAlias.java
+++ b/src/main/java/org/openrewrite/kotlin/RenameTypeAlias.java
@@ -86,7 +86,7 @@ public class RenameTypeAlias extends Recipe {
             Object maybeVd = cursor.getParentTreeCursor().getValue();
             if (maybeVd instanceof J.VariableDeclarations) {
                 J.VariableDeclarations vd = (J.VariableDeclarations) maybeVd;
-                return vd.getLeadingAnnotations().stream().noneMatch(it -> "typealias".equals(it.getSimpleName()));
+                return vd.getModifiers().stream().noneMatch(x -> x.getType() == J.Modifier.Type.LanguageExtension && "typealias".equals(x.getKeyword()));
             }
             return true;
         } else return !(value instanceof J.ParameterizedType);

--- a/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -771,9 +771,10 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
         J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, p);
         mv = mv.withMarkers(spaceBeforeColonAfterDeclarationName(mv.getMarkers()));
 
-        if (multiVariable.getMarkers().findFirst(TypeReferencePrefix.class).orElse(null) != null &&
-                mv.getTypeExpression() != null) {
+        if (mv.getTypeExpression() != null) {
             mv = mv.withTypeExpression(spaceBefore(mv.getTypeExpression(), style.getOther().getAfterColonBeforeDeclarationType()));
+            mv = mv.getPadding().withVariables(ListUtils.mapLast(mv.getPadding().getVariables(),
+                    x -> spaceAfter(x, style.getOther().getBeforeColonAfterDeclarationName())));
         }
         return mv;
     }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -867,7 +867,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         J.Identifier name = createIdentifier(requireNonNull(parameter.getNameIdentifier()), vt, consumedSpaces);
 
         if (parameter.getTypeReference() != null) {
-            markers = markers.addIfAbsent(new TypeReferencePrefix(randomId(), prefix(parameter.getColon())));
             typeExpression = (TypeTree) parameter.getTypeReference().accept(this, data);
             // TODO: get type from IR of KtProperty.
         }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1255,12 +1255,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
         if (typeAlias.getTypeParameterList() != null) {
             typeExpression = (TypeTree) typeAlias.getTypeParameterList().accept(this, data);
-
-            if (typeExpression instanceof J.ParameterizedType) {
-                typeExpression = mapType(typeExpression);
-                Space prefix = name.getPrefix();
-                typeExpression = ((J.ParameterizedType) typeExpression).withClazz(name.withPrefix(Space.EMPTY).withPrefix(prefix));
-            }
         }
 
         Expression expr = convertToExpression(typeAlias.getTypeReference().accept(this, data));

--- a/src/test/java/org/openrewrite/kotlin/tree/CommentTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/CommentTest.java
@@ -170,7 +170,7 @@ class CommentTest implements RewriteTest {
           kotlin(
             """
               fun method() {
-                  val d = {it: Int ->  /*c1*/   it + 42  /***/ } // comment
+                  val d = {it   : Int ->  /*c1*/   it + 42  /***/ } // comment
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/MethodDeclarationTest.java
@@ -39,7 +39,7 @@ class MethodDeclarationTest implements RewriteTest {
     @Test
     void parameters() {
         rewriteRun(
-          kotlin("fun method ( i : Int ) { }")
+          kotlin("fun method ( i : Int, x : Int ) { }")
         );
     }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -120,7 +120,7 @@ class VariableDeclarationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              val isEmpty : Boolean
+              val isEmpty   : Boolean
                   get ( ) : Boolean = 1 == 1
               """
           )
@@ -644,7 +644,7 @@ class VariableDeclarationTest implements RewriteTest {
         rewriteRun(
           kotlin(
             """
-              /*C1*/ typealias Operation =  (Int , Int )   ->    Int
+              /*C1*/ typealias   Operation =  (Int , Int )   ->    Int
               """
           )
         );
@@ -667,7 +667,7 @@ class VariableDeclarationTest implements RewriteTest {
           kotlin(
             """
               class Test {
-                  var t = 1 /*C1*/  ; /*C2*/
+                  var t /*C0*/ : /*C1*/ Int = 1 /*C2*/  ; /*C3*/
                   fun method() {}
               }
               """
@@ -751,6 +751,46 @@ class VariableDeclarationTest implements RewriteTest {
                   set(value) {
                       internalProperty = value
                   }
+              """
+          )
+        );
+    }
+
+    @Test
+    void case1_VariableDeclarations() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  var t /*C1*/ : Int = 1 /*C2*/  ; /*C3*/
+                  fun method() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void case2_MethodParameter() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method ( input /*C0*/ : Any = 1 /*C2*/ , x : Int )  : /*C3*/ Int {
+                 return 1
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void case3_MethodReturnType() {
+        rewriteRun(
+          kotlin(
+            """
+              fun method () /*C3*/ :  Int {
+                 return 1
+              }
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -757,7 +757,7 @@ class VariableDeclarationTest implements RewriteTest {
     }
 
     @Test
-    void case1_VariableDeclarations() {
+    void typeReferencePrefix_1_VariableDeclarations() {
         rewriteRun(
           kotlin(
             """
@@ -771,12 +771,11 @@ class VariableDeclarationTest implements RewriteTest {
     }
 
     @Test
-    void case2_MethodParameter() {
+    void typeReferencePrefix_2_MethodParameter() {
         rewriteRun(
           kotlin(
             """
-              fun method ( input /*C0*/ : Any = 1 /*C2*/ , x : Int )  : /*C3*/ Int {
-                 return 1
+              fun method ( input /*C0*/ : Any = 1 /*C2*/ , x : Int ) {
               }
               """
           )
@@ -784,7 +783,7 @@ class VariableDeclarationTest implements RewriteTest {
     }
 
     @Test
-    void case3_MethodReturnType() {
+    void typeReferencePrefix_3_MethodReturnType() {
         rewriteRun(
           kotlin(
             """


### PR DESCRIPTION
This part of https://github.com/openrewrite/rewrite-kotlin/issues/477
To get rid of  `TypeReferencePrefix` marker from `J.VariableDeclarations`.

Here are 3 `TypeReferencePrefix` use cases
### 1. Variable declaration statement in a block

```kotlin
class Test {
    var t /*C0*/ : /*C1*/ Int = 1 /*C2*/  ; /*C3*/
    fun method() {}
}
```

For this, this PR changes the spaces locations from

```
// "C0" -> Marker of `TypeReferencePrefix`
// "C1" -> prefix of typeExpression
// "C2" -> right padding of variable
```
to
```
// "C0" -> right padding of variable
// "C2" -> right padding of variable of the statement
```


### 2. Variable declaration as Parameters
```kotlin
fun method ( input /*C0*/ : Any = 1 /*C2*/ , x : Int ) {
    return "42"
}
 
```

Change from 
```
// "C0" : marker of `TypeReferencePrefix`
// "C2" : right padding of the statement
```
to
```
// "C0" : right padding of variable
// "C2" : right padding of the statement
```

### 3. Method return type
```kotlin
fun method () /*C3*/ :  Int {
    return 42
}
```
This is not covered by this PR.