### PR TITLE
More type mapping fixes.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -66,7 +66,7 @@ import kotlin.collections.ArrayList
 @Suppress("DuplicatedCode")
 class KotlinTypeMapping(
     private val typeCache: JavaTypeCache,
-    private val firSession: FirSession,
+    val firSession: FirSession,
     private val firFile: FirFile
 ) : JavaTypeMapping<Any> {
 


### PR DESCRIPTION
Changes:

- The name of types bounds of `out` and `in` keywords will contain the correct type.
- Classes that are a select of a field access of type references will contain the correct type.
- Fix type attribution of parameterized types when used in a parameterized type.

fixes #518 
fixse #509
