### PR TITLE
Update `K.Property` model, add `accessors` as a replacement of `setter`/`getter`/`isSetterFirst`

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -277,8 +277,7 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
 
         pr = pr.withVariableDeclarations(visitAndCast(pr.getVariableDeclarations(), p));
         pr = pr.getPadding().withReceiver(visitRightPadded(pr.getPadding().getReceiver(), p));
-        pr = pr.withGetter(visitAndCast(pr.getGetter(), p));
-        pr = pr.withSetter(visitAndCast(pr.getSetter(), p));
+        pr = pr.withAccessors(visitContainer(pr.getAccessors(), p));
         return pr;
     }
 

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -395,14 +395,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             delegate.visitContainer("where", property.getTypeConstraints().getPadding().getConstraints(), JContainer.Location.TYPE_PARAMETERS, ",", "", p);
         }
 
-        if (property.isSetterFirst()) {
-            visit(property.getSetter(), p);
-            visit(property.getGetter(), p);
-        } else {
-            visit(property.getGetter(), p);
-            visit(property.getSetter(), p);
-        }
-
+        visitContainer(property.getAccessors(), p);
         afterSyntax(property, p);
         return property;
     }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2811,13 +2811,10 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         List<J.Modifier> modifiers = mapModifiers(property.getModifierList(), leadingAnnotations, lastAnnotations, data);
         TypeTree typeExpression = null;
         List<JRightPadded<J.VariableDeclarations.NamedVariable>> variables = new ArrayList<>();
-        J.MethodDeclaration getter = null;
-        J.MethodDeclaration setter = null;
         JRightPadded<Expression> receiver = null;
         JContainer<J.TypeParameter> typeParameters = property.getTypeParameterList() != null ?
                 JContainer.build(prefix(property.getTypeParameterList()), mapTypeParameters(property.getTypeParameterList(), data), Markers.EMPTY) : null;
         K.TypeConstraints typeConstraints = null;
-        boolean isSetterFirst = false;
         Set<PsiElement> prefixConsumedSet = preConsumedInfix(property);
 
         modifiers.add(new J.Modifier(
@@ -2867,18 +2864,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             typeExpression = (TypeTree) requireNonNull(property.getTypeReference()).accept(this, data);
         }
 
-        if (property.getGetter() != null) {
-            getter = (J.MethodDeclaration) property.getGetter().accept(this, data);
-        }
-
-        if (property.getSetter() != null) {
-            setter = (J.MethodDeclaration) property.getSetter().accept(this, data);
-        }
-
-        if (getter != null && setter != null) {
-            isSetterFirst = property.getSetter().getTextRange().getStartOffset() < property.getGetter().getTextRange().getStartOffset();
-        }
-
         J.VariableDeclarations variableDeclarations = new J.VariableDeclarations(
                 Tree.randomId(),
                 endFixPrefixAndInfix(property), // overlaps with right-padding of previous statement
@@ -2898,19 +2883,14 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     .withPrefix(prefix(whereKeyword));
         }
 
-        if (getter != null || setter != null || receiver != null || typeConstraints != null) {
-            List<JRightPadded<J.MethodDeclaration>> rps = new ArrayList<>(2);
+        List<KtPropertyAccessor> ktPropertyAccessors = property.getAccessors();
+        if (!ktPropertyAccessors.isEmpty() || receiver != null || typeConstraints != null) {
+            List<JRightPadded<J.MethodDeclaration>> accessors = new ArrayList<>(ktPropertyAccessors.size());
+            PsiElement lastChild = findLastChild(property, c -> !isSpace(c.getNode()) && !isSemicolon(c));
 
-            if (setter != null) {
-                rps.add(padRight(setter, Space.EMPTY));
-            }
-
-            if (getter != null) {
-                rps.add(padRight(getter, Space.EMPTY));
-            }
-
-            if (!isSetterFirst) {
-                Collections.reverse(rps);
+            for (KtPropertyAccessor ktPropertyAccessor : ktPropertyAccessors) {
+                J.MethodDeclaration accessor = (J.MethodDeclaration) ktPropertyAccessor.accept(this, data);
+                accessors.add((lastChild == ktPropertyAccessor) ? padRight(accessor, Space.EMPTY) : maybeTrailingSemicolon(accessor, ktPropertyAccessor));
             }
 
             return new K.Property(
@@ -2920,7 +2900,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     typeParameters,
                     variableDeclarations.withPrefix(Space.EMPTY),
                     typeConstraints,
-                    JContainer.build(rps),
+                    JContainer.build(accessors),
                     receiver
             );
         } else {
@@ -3683,14 +3663,12 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
     private <J2 extends J> JRightPadded<J2> maybeTrailingSemicolon(J2 j, KtElement element) {
         PsiElement maybeSemicolon = findLastNotSpaceChild(element);
-        boolean hasSemicolon = maybeSemicolon instanceof LeafPsiElement && ((LeafPsiElement) maybeSemicolon).getElementType() == KtTokens.SEMICOLON;
-
-        if (hasSemicolon) {
+        if (isSemicolon(maybeSemicolon)) {
             return new JRightPadded<>(j, prefix(maybeSemicolon), Markers.EMPTY.add(new Semicolon(randomId())));
         }
 
         maybeSemicolon = PsiTreeUtil.skipWhitespacesAndCommentsForward(element);
-        if (maybeSemicolon instanceof LeafPsiElement && ((LeafPsiElement) maybeSemicolon).getElementType() == KtTokens.SEMICOLON) {
+        if (isSemicolon(maybeSemicolon)) {
             return new JRightPadded<>(j, deepPrefix(maybeSemicolon), Markers.EMPTY.add(new Semicolon(randomId())));
         }
 

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2913,9 +2913,6 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     typeParameters,
                     variableDeclarations.withPrefix(Space.EMPTY),
                     typeConstraints,
-                    null,
-                    null,
-                    false,
                     JContainer.build(rps),
                     receiver
             );

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2892,6 +2892,20 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         }
 
         if (getter != null || setter != null || receiver != null || typeConstraints != null) {
+            List<JRightPadded<J.MethodDeclaration>> rps = new ArrayList<>(2);
+
+            if (setter != null) {
+                rps.add(padRight(setter, Space.EMPTY));
+            }
+
+            if (getter != null) {
+                rps.add(padRight(getter, Space.EMPTY));
+            }
+
+            if (!isSetterFirst) {
+                Collections.reverse(rps);
+            }
+
             return new K.Property(
                     randomId(),
                     deepPrefix(property),
@@ -2899,9 +2913,10 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     typeParameters,
                     variableDeclarations.withPrefix(Space.EMPTY),
                     typeConstraints,
-                    getter,
-                    setter,
-                    isSetterFirst,
+                    null,
+                    null,
+                    false,
+                    JContainer.build(rps),
                     receiver
             );
         } else {

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1446,6 +1446,7 @@ public interface K extends J {
 
         // For backward compatibility, handle removed fields `getter`, 'setter' and `isSetterFirst` which has been relocated to `accessors`
         // Todo, Remove when all kotlin LSTs have been rebuilt.
+        @Deprecated
         @JsonCreator
         public Property(UUID id,
                         Space prefix,

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1447,16 +1447,16 @@ public interface K extends J {
         // For backward compatibility, handle removed fields `getter`, 'setter' and `isSetterFirst` which has been relocated to `accessors`
         // Todo, Remove when all kotlin LSTs have been rebuilt.
         @JsonCreator
-        public Property(@JsonProperty("id") UUID id,
-                        @JsonProperty("prefix") Space prefix,
-                        @JsonProperty("markers") Markers markers,
-                        @JsonProperty("typeParameters") @Nullable JContainer<TypeParameter> typeParameters,
-                        @JsonProperty("variableDeclarations") VariableDeclarations variableDeclarations,
-                        @JsonProperty("typeConstraints") @Nullable K.TypeConstraints typeConstraints,
+        public Property(UUID id,
+                        Space prefix,
+                        Markers markers,
+                        JContainer<TypeParameter> typeParameters,
+                        VariableDeclarations variableDeclarations,
+                        @Nullable K.TypeConstraints typeConstraints,
                         @JsonProperty("getter") @Nullable J.MethodDeclaration getter,
                         @JsonProperty("setter") @Nullable J.MethodDeclaration setter,
                         @JsonProperty("isSetterFirst") boolean isSetterFirst,
-                        @JsonProperty("receiver") @Nullable JRightPadded<Expression> receiver
+                        @Nullable JRightPadded<Expression> receiver
                         ) {
             this.id = id;
             this.prefix = prefix;

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1454,9 +1454,10 @@ public interface K extends J {
                         JContainer<TypeParameter> typeParameters,
                         VariableDeclarations variableDeclarations,
                         @Nullable K.TypeConstraints typeConstraints,
-                        @JsonProperty("getter") @Nullable J.MethodDeclaration getter,
-                        @JsonProperty("setter") @Nullable J.MethodDeclaration setter,
-                        @JsonProperty("isSetterFirst") boolean isSetterFirst,
+                        @Nullable @JsonProperty("getter") J.MethodDeclaration getter,
+                        @Nullable @JsonProperty("setter") J.MethodDeclaration setter,
+                        @Nullable @JsonProperty("isSetterFirst") Boolean isSetterFirst,
+                        JContainer<J.MethodDeclaration> accessors,
                         @Nullable JRightPadded<Expression> receiver
                         ) {
             this.id = id;
@@ -1466,20 +1467,26 @@ public interface K extends J {
             this.variableDeclarations = variableDeclarations;
             this.typeConstraints = typeConstraints;
 
-            List<JRightPadded<J.MethodDeclaration>> rps = new ArrayList<>(2);
+            if (getter != null || setter != null || isSetterFirst != null) {
+                List<JRightPadded<J.MethodDeclaration>> rps = new ArrayList<>(2);
 
-            if (setter != null) {
-                rps.add(new JRightPadded<>(setter, Space.EMPTY, Markers.EMPTY));
+                // handle old LST removed fields `getter`, 'setter' and `isSetterFirst` which has been relocated to `accessors`
+                if (setter != null) {
+                    rps.add(new JRightPadded<>(setter, Space.EMPTY, Markers.EMPTY));
+                }
+
+                if (getter != null) {
+                    rps.add(new JRightPadded<>(getter, Space.EMPTY, Markers.EMPTY));
+                }
+
+                if (Boolean.FALSE.equals(isSetterFirst)) {
+                    Collections.reverse(rps);
+                }
+                this.accessors = JContainer.build(rps);
+            } else {
+                this.accessors = accessors;
             }
 
-            if (getter != null) {
-                rps.add(new JRightPadded<>(getter, Space.EMPTY, Markers.EMPTY));
-            }
-
-            if (!isSetterFirst) {
-                Collections.reverse(rps);
-            }
-            this.accessors = JContainer.build(rps);
             this.receiver = receiver;
         }
 

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -112,18 +112,20 @@ public class KotlinTypeMappingTest {
         assertThat(id.getType()).isInstanceOf(JavaType.Class.class);
         assertThat(id.getType().toString()).isEqualTo("kotlin.Int");
 
-        JavaType.FullyQualified declaringType = property.getGetter().getMethodType().getDeclaringType();
+        J.MethodDeclaration getter = property.getAccessors().getElements().stream().filter(x -> x.getName().getSimpleName().equals("get")).findFirst().orElse(null);
+        JavaType.FullyQualified declaringType = getter.getMethodType().getDeclaringType();
         assertThat(declaringType.getFullyQualifiedName()).isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat");
-        assertThat(property.getGetter().getMethodType().getName()).isEqualTo("get");
-        assertThat(property.getGetter().getMethodType().getReturnType()).isEqualTo(id.getType());
-        assertThat(property.getGetter().getName().getType()).isEqualTo(property.getGetter().getMethodType());
-        assertThat(property.getGetter().getMethodType().toString().substring(declaringType.toString().length())).isEqualTo("{name=get,return=kotlin.Int,parameters=[]}");
+        assertThat(getter.getMethodType().getName()).isEqualTo("get");
+        assertThat(getter.getMethodType().getReturnType()).isEqualTo(id.getType());
+        assertThat(getter.getName().getType()).isEqualTo(getter.getMethodType());
+        assertThat(getter.getMethodType().toString().substring(declaringType.toString().length())).isEqualTo("{name=get,return=kotlin.Int,parameters=[]}");
 
-        declaringType = property.getSetter().getMethodType().getDeclaringType();
+        J.MethodDeclaration setter = property.getAccessors().getElements().stream().filter(x -> x.getName().getSimpleName().equals("set")).findFirst().orElse(null);
+        declaringType = setter.getMethodType().getDeclaringType();
         assertThat(declaringType.getFullyQualifiedName()).isEqualTo("org.openrewrite.kotlin.KotlinTypeGoat");
-        assertThat(property.getSetter().getMethodType().getName()).isEqualTo("set");
-        assertThat(property.getSetter().getMethodType()).isEqualTo(property.getSetter().getName().getType());
-        assertThat(property.getSetter().getMethodType().toString().substring(declaringType.toString().length())).isEqualTo("{name=set,return=kotlin.Unit,parameters=[kotlin.Int]}");
+        assertThat(setter.getMethodType().getName()).isEqualTo("set");
+        assertThat(setter.getMethodType()).isEqualTo(setter.getName().getType());
+        assertThat(setter.getMethodType().toString().substring(declaringType.toString().length())).isEqualTo("{name=set,return=kotlin.Unit,parameters=[kotlin.Int]}");
     }
 
     @Test

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.internal.PsiTreePrinter;
 import org.openrewrite.kotlin.marker.Implicit;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
@@ -479,6 +480,23 @@ class VariableDeclarationTest implements RewriteTest {
                       set ( value ) {
                           field = value
                       }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void getterSetterWithTrailingSemiColon() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  var stringRepresentation : String = ""
+                      get ( ) = field   ;
+                      set ( value ) {
+                          field = value
+                      } ;
               }
               """
           )

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -23,7 +23,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.kotlin.KotlinParser;
-import org.openrewrite.kotlin.internal.PsiTreePrinter;
 import org.openrewrite.kotlin.marker.Implicit;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;


### PR DESCRIPTION
On `K.Property`, the MethodDeclaration already contains the name `get` or `set` such that we don’t need to separate these and have a boolean `isSetterFirst`. Rather, `JContainer<MethodDeclaration> accessors`
