### PR TITLE
function calls from Kotlin Library.kt will contain the correct declaration type.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -737,12 +737,12 @@ class KotlinTypeMapping(
                             createShallowClass(source.className.fqNameForTopLevelClassMaybeWithDollars.asString())
                         }
                     }
+                } else if (!resolvedSymbol.fir.origin.generated &&
+                    !resolvedSymbol.fir.origin.fromSupertypes &&
+                    !resolvedSymbol.fir.origin.fromSource
+                ) {
+                    declaringType = createShallowClass("kotlin.Library")
                 }
-            } else if (!resolvedSymbol.fir.origin.generated &&
-                !resolvedSymbol.fir.origin.fromSupertypes &&
-                !resolvedSymbol.fir.origin.fromSource
-            ) {
-                declaringType = createShallowClass("kotlin.Library")
             }
         } else {
             declaringType = TypeUtils.asFullyQualified(type(function.typeRef))

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -375,12 +375,12 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
                             source.className.fqNameForTopLevelClassMaybeWithDollars.asString()
                         }
                     }
+                } else if (!resolvedSymbol.fir.origin.generated &&
+                    !resolvedSymbol.fir.origin.fromSupertypes &&
+                    !resolvedSymbol.fir.origin.fromSource
+                ) {
+                    declaringSig = "kotlin.Library"
                 }
-            } else if (!resolvedSymbol.fir.origin.generated &&
-                !resolvedSymbol.fir.origin.fromSupertypes &&
-                !resolvedSymbol.fir.origin.fromSource
-            ) {
-                declaringSig = "kotlin.Library"
             }
         } else if (sym is FirFunctionSymbol<*>) {
             declaringSig = signature(function.typeRef)

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -1519,5 +1519,28 @@ public class KotlinTypeMappingTest {
               )
             );
         }
+
+        @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/526")
+        @Test
+        void methodDeclarationType() {
+            rewriteRun(
+              kotlin(
+                """
+                 val arr = arrayOf(1, 2, 3)
+                 """, spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean found = new AtomicBoolean(false);
+                    new KotlinIsoVisitor<Integer>() {
+                        @Override
+                        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer integer) {
+                            assertThat(method.getMethodType().toString()).isEqualTo("kotlin.Library{name=arrayOf,return=kotlin.Array<kotlin.Int>,parameters=[kotlin.Array<Generic{? extends Generic{T}}>]}");
+                            found.set(true);
+                            return super.visitMethodInvocation(method, integer);
+                        }
+                    }.visit(cu, 0);
+                    assertThat(found.get()).isTrue();
+                })
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
Changes:

- function calls from the `Kotlin` `Library.kt` will contain a declaring type of `kotlin.Library`. Note: there aren't any cases from the tests where a `FirDeclarationOrigin.Library` that is not from a JVM source comes from the `kotlin.Library` class, but it does not mean that other libraries may exist. So, it's possible we may need to make further improvements. In the IR the parent field is `kotlin`, which would result in `kotlin{name=arrayOf...` instead of `kotlinLibraryKt{name=arrayOf`. So, when we move to the IR it will require updates to various method type assertions.

fixes #526 