### PR TITLE
Various fixes for SAM constructors.

### DIFF
--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.references.FirSuperReference
 import org.jetbrains.kotlin.fir.references.toResolvedBaseSymbol
+import org.jetbrains.kotlin.fir.resolve.calls.FirSyntheticFunctionSymbol
 import org.jetbrains.kotlin.fir.resolve.inference.ConeTypeParameterBasedTypeVariable
 import org.jetbrains.kotlin.fir.resolve.providers.toSymbol
 import org.jetbrains.kotlin.fir.resolve.toFirRegularClass
@@ -390,9 +391,10 @@ class KotlinTypeSignatureBuilder(private val firSession: FirSession, private val
         }
 
         val sig = StringBuilder(declaringSig)
-        when (sym) {
-            is FirConstructorSymbol -> sig.append("{name=<constructor>,return=${signature(function.typeRef)}")
-            is FirNamedFunctionSymbol -> {
+        when {
+            sym is FirConstructorSymbol ||
+                    sym is FirSyntheticFunctionSymbol && sym.origin == FirDeclarationOrigin.SamConstructor -> sig.append("{name=<constructor>,return=${signature(function.typeRef)}")
+            sym is FirNamedFunctionSymbol -> {
                 sig.append("{name=${sym.name.asString()}")
                 sig.append(",return=${signature(function.typeRef)}")
             }

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.fir.psi
 import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.references.resolved
+import org.jetbrains.kotlin.fir.resolve.calls.FirSyntheticFunctionSymbol
 import org.jetbrains.kotlin.fir.resolve.providers.toSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
@@ -326,9 +327,11 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
                 if (fir.calleeReference is FirErrorNamedReference)
                     return null
 
-                when (fir.calleeReference.resolved?.resolvedSymbol) {
-                    is FirConstructorSymbol -> ExpressionType.CONSTRUCTOR
-                    is FirNamedFunctionSymbol -> ExpressionType.METHOD_INVOCATION
+                val sym = fir.calleeReference.resolved?.resolvedSymbol
+                when {
+                    sym is FirConstructorSymbol ||
+                            sym is FirSyntheticFunctionSymbol && sym.origin == FirDeclarationOrigin.SamConstructor -> ExpressionType.CONSTRUCTOR
+                    sym is FirNamedFunctionSymbol -> ExpressionType.METHOD_INVOCATION
                     else -> throw UnsupportedOperationException("Unsupported resolved symbol: ${fir.calleeReference.resolved?.resolvedSymbol?.javaClass}")
                 }
             }


### PR DESCRIPTION
Changes:

- Fixed call type returned by PsiElementAssociations#getCallType.
- Fixed method type for SAM constructors.

fixes #527
fixes #529 
