### PR TITLE
Set the type on identifiers of function type parameters.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -623,7 +623,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     typeTree = new K.FunctionType.Parameter(
                             randomId(),
                             Markers.EMPTY.addIfAbsent(new TypeReferencePrefix(randomId(), prefix(ktParameter.getColon()))),
-                            createIdentifier(ktParameter.getNameIdentifier(), null),
+                            createIdentifier(ktParameter.getNameIdentifier(), type(ktParameter.getTypeReference())),
                             (TypeTree) requireNonNull(ktParameter.getTypeReference()).accept(this, data)
                     );
                 } else {

--- a/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinTypeMappingTest.java
@@ -1495,5 +1495,29 @@ public class KotlinTypeMappingTest {
               )
             );
         }
+
+        @Test
+        void functionTypeOnParams() {
+            rewriteRun(
+              kotlin(
+                """
+                 fun foo() :   suspend    ( param : Int )  -> Unit = { }
+                 """, spec -> spec.afterRecipe(cu -> {
+                    AtomicBoolean found = new AtomicBoolean(false);
+                    new KotlinIsoVisitor<Integer>() {
+                        @Override
+                        public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                            if ("param".equals(identifier.getSimpleName()) && identifier.getType() != null) {
+                                assertThat(identifier.getType().toString()).isEqualTo("kotlin.Int");
+                                found.set(true);
+                            }
+                            return super.visitIdentifier(identifier, integer);
+                        }
+                    }.visit(cu, 0);
+                    assertThat(found.get()).isTrue();
+                })
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
Changes:

- The identifier of FunctionType parameters will contain the type.

fixes #536 