### PR TITLE
Introduce `K.UseSite` and deprecate `AnnotationUseSite` marker

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -325,6 +325,25 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         return u;
     }
 
+    public J visitUseSite(K.UseSite useSite, P p) {
+        K.UseSite u = useSite;
+
+        u = u.withPrefix(visitSpace(u.getPrefix(), Space.Location.ANNOTATION_ARGUMENTS, p));
+        u = u.withMarkers(visitMarkers(u.getMarkers(), p));
+
+        Expression temp = (Expression) visitExpression(u, p);
+        if (!(temp instanceof K.UseSite)) {
+            return temp;
+        } else {
+            u = (K.UseSite) temp;
+        }
+
+        u = u.getPadding().withTarget(visitRightPadded(u.getPadding().getTarget(), JRightPadded.Location.ANNOTATION_ARGUMENT, p));
+        u = u.withType(visitType(u.getType(), p));
+
+        return u;
+    }
+
     public J visitWhen(K.When when, P p) {
         K.When w = when;
         w = w.withPrefix(visitSpace(w.getPrefix(), KSpace.Location.WHEN_PREFIX, p));
@@ -419,10 +438,7 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
     @Override
     public <M extends Marker> M visitMarker(Marker marker, P p) {
         Marker m = super.visitMarker(marker, p);
-        if (m instanceof AnnotationUseSite) {
-            AnnotationUseSite acs = (AnnotationUseSite) marker;
-            m = acs.withPrefix(visitSpace(acs.getPrefix(), KSpace.Location.ANNOTATION_CALL_SITE_PREFIX, p));
-        } else if (marker instanceof IsNullable) {
+        if (marker instanceof IsNullable) {
             IsNullable isn = (IsNullable) marker;
             m = isn.withPrefix(visitSpace(isn.getPrefix(), KSpace.Location.IS_NULLABLE_PREFIX, p));
         } else if (marker instanceof TypeReferencePrefix) {

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -433,6 +433,19 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     }
 
     @Override
+    public J visitUseSite(K.UseSite useSite, PrintOutputCapture<P> p) {
+        beforeSyntax(useSite, Space.Location.ANNOTATIONS, p);
+        visit(useSite.getTarget(), p);
+        visitSpace(useSite.getPadding().getTarget().getAfter(), Space.Location.ANNOTATIONS, p);
+
+        if (!(useSite.getTarget() instanceof J.Empty)) {
+            p.append(":");
+        }
+
+        return useSite;
+    }
+
+    @Override
     public J visitWhen(K.When when, PrintOutputCapture<P> p) {
         beforeSyntax(when, KSpace.Location.WHEN_PREFIX, p);
         p.append("when");
@@ -484,12 +497,11 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             String afterArgs = ")";
             String delimiter = ",";
 
-            AnnotationUseSite useSite = annotation.getMarkers().findFirst(AnnotationUseSite.class).orElse(null);
-            if (useSite != null) {
-                kotlinPrinter.visitSpace(useSite.getPrefix(), KSpace.Location.ANNOTATION_CALL_SITE_PREFIX, p);
-                p.append(":");
+            boolean isUseSite = annotation.getAnnotationType() instanceof K.UseSite;
+            if (isUseSite) {
+                boolean isImplicitBracket = ((K.UseSite) annotation.getAnnotationType()).isImplicitBracket();
 
-                if (!useSite.isImplicitBracket()) {
+                if (!isImplicitBracket) {
                     beforeArgs = "[";
                     afterArgs = "]";
                 } else {

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -434,7 +434,7 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
     @Override
     public J visitUseSite(K.UseSite useSite, PrintOutputCapture<P> p) {
-        beforeSyntax(useSite, Space.Location.ANNOTATIONS, p);
+        beforeSyntax(useSite, Space.Location.ANNOTATION_PREFIX, p);
         visit(useSite.getTarget(), p);
         visitSpace(useSite.getPadding().getTarget().getAfter(), Space.Location.ANNOTATIONS, p);
 

--- a/src/main/java/org/openrewrite/kotlin/marker/AnnotationUseSite.java
+++ b/src/main/java/org/openrewrite/kotlin/marker/AnnotationUseSite.java
@@ -22,6 +22,7 @@ import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
 
+@Deprecated
 @Value
 @With
 public class AnnotationUseSite implements Marker {

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -2040,4 +2040,90 @@ public interface K extends J {
         }
     }
 
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @RequiredArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    final class UseSite implements K, NameTree, Expression {
+        @Nullable
+        @NonFinal
+        transient WeakReference<K.UseSite.Padding> padding;
+
+        @Getter
+        @With
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        @Getter
+        @With
+        Space prefix;
+
+        @Getter
+        @With
+        Markers markers;
+
+        JRightPadded<NameTree> target;
+
+        @Getter
+        @With
+        boolean isImplicitBracket;
+
+        public NameTree getTarget() {
+            return target.getElement();
+        }
+
+        @Override
+        public @Nullable JavaType getType() {
+            // use site has no type
+            return null;
+        }
+
+        @Override
+        public <T extends J> T withType(@Nullable JavaType type) {
+            return (T) this;
+        }
+
+        @Override
+        public <P> J acceptKotlin(KotlinVisitor<P> v, P p) {
+            return v.visitUseSite(this, p);
+        }
+
+        @Override
+        public CoordinateBuilder.Expression getCoordinates() {
+            return new CoordinateBuilder.Expression(this);
+        }
+
+        public K.UseSite.Padding getPadding() {
+            K.UseSite.Padding p;
+            if (this.padding == null) {
+                p = new K.UseSite.Padding(this);
+                this.padding = new WeakReference<>(p);
+            } else {
+                p = this.padding.get();
+                if (p == null || p.t != this) {
+                    p = new K.UseSite.Padding(this);
+                    this.padding = new WeakReference<>(p);
+                }
+            }
+            return p;
+        }
+
+        @RequiredArgsConstructor
+        public static class Padding {
+            private final K.UseSite t;
+
+            public JRightPadded<NameTree> getTarget() {
+                return t.target;
+            }
+
+            public K.UseSite withTarget(JRightPadded<NameTree> target) {
+                return t.target == target ? t : new K.UseSite(t.id,
+                        t.prefix,
+                        t.markers,
+                        target,
+                        t.isImplicitBracket);
+            }
+        }
+    }
+
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -588,11 +588,26 @@ class AnnotationTest implements RewriteTest {
             """
               import javax.inject.Inject
               import javax.inject.Named
-              
+
               class Test {
                   @field :  [   Inject    Named (  "numberfield "   )    ]
                   var field: Long = 0
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyNameUseSiteAnnotation() {
+        rewriteRun(
+          kotlin(
+            """
+              annotation class Anno1
+              annotation class Anno2
+
+              @[ Anno1 Anno2 ]
+              val x = 42
               """
           )
         );

--- a/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/AnnotationTest.java
@@ -683,4 +683,36 @@ class AnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void allUseSiteCases() {
+        rewriteRun(
+          kotlin(
+            """
+              annotation class Ann1
+              annotation class Ann2
+
+              // case 0, Non use-site, regular annotation
+              @Ann1
+              val x1 = 40
+
+              // case 1, use-site, implicit bracket
+              @field : Ann1
+              val x2 = 41
+
+              // case 2, use-site, explicit bracket
+              @field : [ Ann1 ]
+              val x3 = 42
+
+              // case 3, use-site, multi annotations with explicit bracket
+              @field : [Ann1 Ann2]
+              val x4 = 43
+
+              // case 4, use-site, empty target
+              @[ Ann1 Ann2]
+              val x5 = 44
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
1. Introduce `K.UseSite` which is a `NameTree`, and will be the `annotationType` in a `J.Annotation`.
2. Deprecate `AnnotationUseSite` marker
3. For empty name use-site annotation like this `@[ Anno1 Anno2 ]`, the target will be an `J.Empty`

Notes:
This PR requires a small rewrite code change to `J.Annotation#getSimpleName()`
from
```java
        public String getSimpleName() {
            return annotationType instanceof Identifier ?
                    ((Identifier) annotationType).getSimpleName() :
                    ((J.FieldAccess) annotationType).getSimpleName();
        }
```
to
```java
        public String getSimpleName() {
            if (annotationType instanceof Identifier) {
                return ((Identifier) annotationType).getSimpleName();
            } else if (annotationType instanceof J.FieldAccess ) {
                return ((J.FieldAccess) annotationType).getSimpleName();
            } else {
                return annotationType.toString();
            }
        }
```