### PR TITLE
Improve condition of nested inner class type fetching

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/PsiTreePrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/PsiTreePrinter.java
@@ -549,6 +549,10 @@ public class PsiTreePrinter {
             return printConeKotlinType(coneKotlinType);
         } else if (firElement instanceof FirResolvedNamedReference) {
             return ((FirResolvedNamedReference) firElement).getName().toString();
+        } else if (firElement instanceof FirResolvedQualifier) {
+            FirResolvedQualifier qualifier = (FirResolvedQualifier) firElement;
+            FqName fqName = qualifier.getRelativeClassFqName();
+            return fqName != null ? " RelativeClassFqName: " + fqName : "";
         } else if (firElement instanceof FirFunctionCall) {
             FirFunctionCall functionCall = (FirFunctionCall) firElement;
             if (functionCall.getExplicitReceiver() != null) {

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -169,8 +169,8 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
 
     private fun matchClassId(psi: PsiElement, classId: ClassId): ClassId {
         if (psi.parent is KtDotQualifiedExpression) {
-            val parts = psi.parent.text.split(".")
-            if (classId.packageFqName.isRoot && parts.size == 2 && psi.text == parts[0]) {
+            val parent: KtDotQualifiedExpression = psi.parent as KtDotQualifiedExpression
+            if (classId.packageFqName.isRoot && psi !is KtDotQualifiedExpression && psi == parent.receiverExpression) {
                 // Match the current PSI to the ClassId if the PSI is the outermost class of a dot qualified expression.
                 // For a multi-nested class like A.B.A.C, the PSI#parent field will have the same result (A.B) for both the LHS A and B.
                 // To match the PSI to the ClassId the outermost class `A` should use the current PSI rather than the parent field `A.B`.


### PR DESCRIPTION
To address the comment in this [PR](https://github.com/openrewrite/rewrite-kotlin/pull/547).
I'm concerned that the conditions here may not be very persuasive and conducive to understanding, so there should be an alternative condition of using PSI/FIR elements.

so instead of `parts.size == 2 && psi.text == parts[0]`, I think the condition can be optimized to `psi !is KtDotQualifiedExpression && psi == parent.receiverExpression`