### PR TITLE
Fixed NPE from while loop with no body.

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1635,7 +1635,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 deepPrefix(expression),
                 Markers.EMPTY,
                 mapControlParentheses(requireNonNull(expression.getCondition()), data).withPrefix(prefix(expression.getLeftParenthesis())),
-                JRightPadded.build(requireNonNull(expression.getBody()).accept(this, data).withPrefix(prefix(expression.getBody().getParent())))
+                expression.getBody() == null ? JRightPadded.build(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)) : JRightPadded.build(requireNonNull(expression.getBody()).accept(this, data).withPrefix(prefix(expression.getBody().getParent())))
         );
     }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/WhileLoopTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/WhileLoopTest.java
@@ -73,4 +73,19 @@ class WhileLoopTest implements RewriteTest {
           )
         );
     }
+
+    @SuppressWarnings("ControlFlowWithEmptyBody")
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/561")
+    @Test
+    void noBody() {
+        rewriteRun(
+          kotlin(
+            """
+              fun test ( ) {
+                  while ( true );
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Changes:

- Parsing a while loop will not NPE due to `requireNonNull`.
fixes #561