### PR TITLE
Enable context receivers in the Kotlin compiler configuration

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -349,6 +349,7 @@ public class KotlinParser implements Parser {
         addJvmClasspathRoot(compilerConfiguration, PathUtil.getResourcePathForClass(AnnotationTarget.class));
 
         K2JVMCompilerArguments arguments = new K2JVMCompilerArguments();
+        arguments.setContextReceivers(true);
         configureJdkHome(compilerConfiguration, arguments);
         configureJavaModulesContentRoots(compilerConfiguration, arguments);
         configureAdvancedJvmOptions(compilerConfiguration, arguments);


### PR DESCRIPTION
Changes:
- Enabled context receivers in the compiler configuration.

This is related to https://github.com/openrewrite/rewrite-kotlin/issues/460.