### PR TITLE
Fix issue of whitespace lost on empty while-loop body before trailing semi-colon

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1622,7 +1622,8 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 deepPrefix(expression),
                 Markers.EMPTY,
                 mapControlParentheses(requireNonNull(expression.getCondition()), data).withPrefix(prefix(expression.getLeftParenthesis())),
-                expression.getBody() == null ? JRightPadded.build(new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY)) : JRightPadded.build(requireNonNull(expression.getBody()).accept(this, data).withPrefix(prefix(expression.getBody().getParent())))
+                expression.getBody() == null ? JRightPadded.build(new J.Empty(randomId(), suffix(expression.getRightParenthesis()), Markers.EMPTY)) :
+                        JRightPadded.build(requireNonNull(expression.getBody()).accept(this, data).withPrefix(prefix(expression.getBody().getParent())))
         );
     }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/WhileLoopTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/WhileLoopTest.java
@@ -82,7 +82,7 @@ class WhileLoopTest implements RewriteTest {
           kotlin(
             """
               fun test ( ) {
-                  while ( true );
+                  while ( true )   ;
               }
               """
           )


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-kotlin/issues/574

This happens with an empty while-loop body only, the missing whitespace should be the prefix of the empty body which is a `J.Empty`.
