### PR TITLE
Support shebang parsing

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -61,11 +61,11 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
 
     @Override
     public J visitCompilationUnit(K.CompilationUnit sourceFile, PrintOutputCapture<P> p) {
-        beforeSyntax(sourceFile, Space.Location.COMPILATION_UNIT_PREFIX, p);
-
         if (sourceFile.getShebang() != null) {
             p.append(sourceFile.getShebang());
         }
+
+        beforeSyntax(sourceFile, Space.Location.COMPILATION_UNIT_PREFIX, p);
 
         visit(sourceFile.getAnnotations(), p);
 

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -63,6 +63,10 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
     public J visitCompilationUnit(K.CompilationUnit sourceFile, PrintOutputCapture<P> p) {
         beforeSyntax(sourceFile, Space.Location.COMPILATION_UNIT_PREFIX, p);
 
+        if (sourceFile.getShebang() != null) {
+            p.append(sourceFile.getShebang());
+        }
+
         visit(sourceFile.getAnnotations(), p);
 
         JRightPadded<J.Package> pkg = sourceFile.getPadding().getPackageDeclaration();

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -98,6 +98,11 @@ public interface K extends J {
 
         @With
         @Getter
+        @Nullable
+        String shebang;
+
+        @With
+        @Getter
         Space prefix;
 
         @With
@@ -287,7 +292,7 @@ public interface K extends J {
             }
 
             public K.CompilationUnit withPackageDeclaration(@Nullable JRightPadded<Package> packageDeclaration) {
-                return t.packageDeclaration == packageDeclaration ? t : new K.CompilationUnit(t.id, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, null,
+                return t.packageDeclaration == packageDeclaration ? t : new K.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, null,
                         t.annotations, packageDeclaration, t.imports, t.statements, t.eof);
             }
 
@@ -310,7 +315,7 @@ public interface K extends J {
                         .map(i -> (JRightPadded<Statement>) (Object) i)
                         .collect(Collectors.toList()));
 
-                return t.getPadding().getClasses() == classes ? t : new K.CompilationUnit(t.id, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.annotations, t.packageDeclaration, t.imports, statements, t.eof);
+                return t.getPadding().getClasses() == classes ? t : new K.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.annotations, t.packageDeclaration, t.imports, statements, t.eof);
             }
 
             @Override
@@ -320,7 +325,7 @@ public interface K extends J {
 
             @Override
             public K.CompilationUnit withImports(List<JRightPadded<Import>> imports) {
-                return t.imports == imports ? t : new K.CompilationUnit(t.id, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, null,
+                return t.imports == imports ? t : new K.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath, t.fileAttributes, t.charsetName, t.charsetBomMarked, null,
                         t.annotations, t.packageDeclaration, imports, t.statements, t.eof);
             }
 
@@ -329,7 +334,7 @@ public interface K extends J {
             }
 
             public K.CompilationUnit withStatements(List<JRightPadded<Statement>> statements) {
-                return t.statements == statements ? t : new K.CompilationUnit(t.id, t.prefix, t.markers, t.sourcePath,
+                return t.statements == statements ? t : new K.CompilationUnit(t.id, t.shebang, t.prefix, t.markers, t.sourcePath,
                         t.fileAttributes, t.charsetName, t.charsetBomMarked, t.checksum, t.annotations, t.packageDeclaration, t.imports, statements, t.eof);
             }
         }

--- a/src/test/java/org/openrewrite/kotlin/tree/CompilationUnitTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/CompilationUnitTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
@@ -68,17 +70,34 @@ class CompilationUnitTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/569")
-    @Test
-    void shebang() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "class Foo",
+      "val x = 1",
+      """
+        import java.util.Objects
+
+        class A
+        """,
+      """
+        package x.y
+
+        class A
+        """,
+      """
+        package x.y
+        import java.util.Objects
+
+        class A
+        """
+    })
+    void shebang(String fileContent) {
         rewriteRun(
-          kotlin(
-            """
-              #!/usr/bin/env who
-              
-              class Foo
-              """
-          )
+          kotlin("""
+            #!/usr/bin/env who
+            
+            %s
+            """.formatted(fileContent))
         );
     }
 }

--- a/src/test/java/org/openrewrite/kotlin/tree/CompilationUnitTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/CompilationUnitTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
@@ -63,6 +64,20 @@ class CompilationUnitTest implements RewriteTest {
               // C2
               """,
             SourceSpec::noTrim
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/569")
+    @Test
+    void shebang() {
+        rewriteRun(
+          kotlin(
+            """
+              #!/usr/bin/env who
+              
+              class Foo
+              """
           )
         );
     }


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-kotlin/issues/569

Following the same pattern in groovy, added a nullable string to `K.CompilationUnit` for shebang.