### PR TITLE
Fix Semi-colon on inline methods after property declaration disappears

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -289,7 +289,7 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
             pr = (K.Property) temp;
         }
 
-        pr = pr.withVariableDeclarations(visitAndCast(pr.getVariableDeclarations(), p));
+        pr = pr.getPadding().withVariableDeclarations(visitRightPadded(pr.getPadding().getVariableDeclarations(), p));
         pr = pr.getPadding().withReceiver(visitRightPadded(pr.getPadding().getReceiver(), p));
         pr = pr.withAccessors(visitContainer(pr.getAccessors(), p));
         return pr;

--- a/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -352,13 +352,13 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
         if (prop.getPadding().getReceiver() != null) {
             prop = prop.getPadding().withReceiver(prop.getPadding().getReceiver().withAfter(updateSpace(prop.getPadding().getReceiver().getAfter(), false)));
         }
+
         if (prop.getVariableDeclarations() != null && !prop.getVariableDeclarations().getVariables().isEmpty()) {
-            prop = prop.withVariableDeclarations(
-                    prop.getVariableDeclarations().withVariables(
-                            ListUtils.mapFirst(prop.getVariableDeclarations().getVariables(),
-                                    v -> spaceBefore(v, false))
-                    )
-            );
+            List<J.VariableDeclarations.NamedVariable> variables = ListUtils.mapFirst(prop.getVariableDeclarations().getVariables(),
+                    v -> spaceBefore(v, false));
+            JRightPadded<J.VariableDeclarations> rp = prop.getPadding().getVariableDeclarations();
+            rp = rp.withElement(rp.getElement().withVariables(variables));
+            prop = prop.getPadding().withVariableDeclarations(rp);
         }
         return prop;
     }

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinPrinter.java
@@ -388,6 +388,11 @@ public class KotlinPrinter<P> extends KotlinVisitor<PrintOutputCapture<P>> {
             delegate.visitContainer("where", property.getTypeConstraints().getPadding().getConstraints(), JContainer.Location.TYPE_PARAMETERS, ",", "", p);
         }
 
+        visitSpace(property.getPadding().getVariableDeclarations().getAfter(), Space.Location.VARIABLE_INITIALIZER, p);
+        if (property.getPadding().getVariableDeclarations().getMarkers().findFirst(Semicolon.class).isPresent()) {
+            p.append(";");
+        }
+
         visitContainer(property.getAccessors(), p);
         afterSyntax(property, p);
         return property;

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2958,7 +2958,19 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         if (!ktPropertyAccessors.isEmpty() || receiver != null || typeConstraints != null) {
             List<JRightPadded<J.MethodDeclaration>> accessors = new ArrayList<>(ktPropertyAccessors.size());
 
-            for (KtPropertyAccessor ktPropertyAccessor : ktPropertyAccessors) {
+            Space beforeSemiColon = Space.EMPTY;
+            Markers rpMarkers = Markers.EMPTY;
+            for (int i = 0; i < ktPropertyAccessors.size(); i++) {
+                KtPropertyAccessor ktPropertyAccessor = ktPropertyAccessors.get(i);
+
+                if (i == 0) {
+                    PsiElement maybeSemiColon = PsiTreeUtil.findSiblingBackward(ktPropertyAccessor, KtTokens.SEMICOLON, null);
+                    if (maybeSemiColon != null) {
+                        beforeSemiColon = prefix(maybeSemiColon);
+                        rpMarkers = rpMarkers.addIfAbsent(new Semicolon(randomId()));
+                    }
+                }
+
                 J.MethodDeclaration accessor = (J.MethodDeclaration) ktPropertyAccessor.accept(this, data);
                 accessors.add(maybeTrailingSemicolonInternal(accessor, ktPropertyAccessor));
             }
@@ -2968,7 +2980,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     deepPrefix(property),
                     markers,
                     typeParameters,
-                    variableDeclarations.withPrefix(Space.EMPTY),
+                    padRight(variableDeclarations.withPrefix(Space.EMPTY), beforeSemiColon, rpMarkers),
                     typeConstraints,
                     JContainer.build(accessors),
                     receiver

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1504,7 +1504,7 @@ public interface K extends J {
             return typeParameters == null ? null : typeParameters.getElements();
         }
 
-        J.VariableDeclarations variableDeclarations;
+        JRightPadded<J.VariableDeclarations> paddedVariableDeclarations;
 
         @Nullable
         TypeConstraints typeConstraints;
@@ -1523,7 +1523,8 @@ public interface K extends J {
                         Space prefix,
                         Markers markers,
                         JContainer<TypeParameter> typeParameters,
-                        VariableDeclarations variableDeclarations,
+                        @Nullable JRightPadded<J.VariableDeclarations> paddedVariableDeclarations,
+                        @Nullable VariableDeclarations variableDeclarations,
                         @Nullable K.TypeConstraints typeConstraints,
                         @Nullable @JsonProperty("getter") J.MethodDeclaration getter,
                         @Nullable @JsonProperty("setter") J.MethodDeclaration setter,
@@ -1535,7 +1536,14 @@ public interface K extends J {
             this.prefix = prefix;
             this.markers = markers;
             this.typeParameters = typeParameters;
-            this.variableDeclarations = variableDeclarations;
+
+            if (variableDeclarations != null) {
+                // from old LST
+                this.paddedVariableDeclarations = new JRightPadded<>(variableDeclarations, Space.EMPTY, Markers.EMPTY);
+            } else {
+                this.paddedVariableDeclarations = requireNonNull(paddedVariableDeclarations);
+            }
+
             this.typeConstraints = typeConstraints;
 
             if (getter != null || setter != null || isSetterFirst != null) {
@@ -1559,6 +1567,10 @@ public interface K extends J {
             }
 
             this.receiver = receiver;
+        }
+
+        public J.VariableDeclarations getVariableDeclarations() {
+            return paddedVariableDeclarations.getElement();
         }
 
         @Nullable
@@ -1602,6 +1614,15 @@ public interface K extends J {
         public static class Padding {
             private final Property t;
 
+            public JRightPadded<J.VariableDeclarations> getVariableDeclarations() {
+                return t.paddedVariableDeclarations;
+            }
+
+            public Property withVariableDeclarations(JRightPadded<J.VariableDeclarations> variableDeclarations) {
+                return t.paddedVariableDeclarations == variableDeclarations ? t : new Property(t.id, t.prefix, t.markers, t.typeParameters,
+                        variableDeclarations, t.typeConstraints, t.accessors, t.receiver);
+            }
+
             @Nullable
             public JContainer<TypeParameter> getTypeParameters() {
                 return t.typeParameters;
@@ -1609,7 +1630,7 @@ public interface K extends J {
 
             public Property withTypeParameters(@Nullable JContainer<TypeParameter> typeParameters) {
                 return t.typeParameters == typeParameters ? t : new Property(t.id, t.prefix, t.markers, typeParameters,
-                        t.variableDeclarations, t.typeConstraints, t.accessors, t.receiver);
+                        t.paddedVariableDeclarations, t.typeConstraints, t.accessors, t.receiver);
             }
 
             @Nullable
@@ -1620,7 +1641,7 @@ public interface K extends J {
             @Nullable
             public Property withReceiver(@Nullable JRightPadded<Expression> receiver) {
                 return t.receiver == receiver ? t : new Property(t.id, t.prefix, t.markers, t.typeParameters,
-                        t.variableDeclarations, t.typeConstraints, t.accessors, receiver);
+                        t.paddedVariableDeclarations, t.typeConstraints, t.accessors, receiver);
             }
         }
     }

--- a/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/VariableDeclarationTest.java
@@ -520,6 +520,20 @@ class VariableDeclarationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/560")
+    @Test
+    void accessorAfterTrailingSemiColon() {
+        rewriteRun(
+          kotlin(
+            """
+              class Test {
+                  var n: Int = 0  ;   protected set
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/135")
     @Test
     void checkNonNull() {


### PR DESCRIPTION
fixes https://github.com/openrewrite/rewrite-kotlin/issues/560

An code example:
```java
class Test {
    var n: Int = 0 /*C1*/ ;   protected set
}
```

1. ` var n: Int = 0 /*C1*/ ;   protected set` is a `K.Property`.

2. `protected set` is a setter accessor in the `K.Property`,  it can be in a new line and then no semi-colon is required, but it can be in the same line and then a semi-colon is required as a delimiter.
For the latter case with a semi-colon inside a `K.Property`, However,  there is not a space room for `/*C1*/` in  `K.Property`. 

This PR proposed to change variable declarations in  `K.Property` from type `J.VariableDeclarations` to  `JRightPadded<J.VariableDeclarations>`, plus `SemiColon` marker, then this case can be handled.