### PR TITLE
Bump Kotlin to 1.9.22

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "1.9.22"
 }
 group = "org.openrewrite"
 description = "Rewrite Kotlin"
@@ -13,7 +13,7 @@ val latest = if (project.hasProperty("releasing")) {
     "latest.integration"
 }
 
-val kotlinVersion = "1.9.0"
+val kotlinVersion = "1.9.22"
 
 dependencies {
     annotationProcessor("org.projectlombok:lombok:latest.release")

--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -437,6 +437,7 @@ public class KotlinParser implements Parser {
                 libraryScope,
                 compilerConfiguration.get(LOOKUP_TRACKER),
                 compilerConfiguration.get(ENUM_WHEN_TRACKER),
+                compilerConfiguration.get(IMPORT_TRACKER),
                 null, // Do not incrementally compile
                 emptyList(), // Add extension registrars when needed here.
                 true,

--- a/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1667,7 +1667,7 @@ public interface K extends J {
 
         @Override
         public @Nullable JavaType getType() {
-            return expression.getType() != null ? new JavaType.Array(null, expression.getType()) : null;
+            return expression.getType() != null ? new JavaType.Array(null, expression.getType(), null) : null;
         }
 
         @Override

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeIrSignatureBuilder.kt
@@ -132,8 +132,8 @@ class KotlinTypeIrSignatureBuilder : JavaTypeSignatureBuilder {
             throw UnsupportedOperationException("Unsupported parent of alias signature " + type.javaClass)
         }
         val s = StringBuilder()
-        if ((type.parent as IrFile).fqName.asString().isNotEmpty()) {
-            s.append((type.parent as IrFile).fqName.asString()).append(".")
+        if ((type.parent as IrFile).packageFqName.asString().isNotEmpty()) {
+            s.append((type.parent as IrFile).packageFqName.asString()).append(".")
         }
         s.append(type.name.asString())
         val joiner = StringJoiner(", ", "<", ">")
@@ -145,13 +145,13 @@ class KotlinTypeIrSignatureBuilder : JavaTypeSignatureBuilder {
     }
 
     private fun externalPackageFragmentSignature(baseType: IrExternalPackageFragment): String {
-        return baseType.fqName.asString()
+        return baseType.packageFqName.asString()
     }
 
     private fun fileSignature(type: IrFile): String {
-        return (if (type.fqName.asString()
+        return (if (type.packageFqName.asString()
                 .isNotEmpty()
-        ) type.fqName.asString() + "." else "") + type.name.replace(".kt", "Kt")
+        ) type.packageFqName.asString() + "." else "") + type.name.replace(".kt", "Kt")
     }
 
     /**

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeMapping.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.fir.analysis.checkers.getContainingClassSymbol
 import org.jetbrains.kotlin.fir.analysis.checkers.modality
 import org.jetbrains.kotlin.fir.analysis.checkers.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.declarations.*
-import org.jetbrains.kotlin.fir.declarations.impl.FirOuterClassTypeParameterRef
 import org.jetbrains.kotlin.fir.declarations.impl.FirPrimaryConstructor
 import org.jetbrains.kotlin.fir.declarations.utils.isLocal
 import org.jetbrains.kotlin.fir.declarations.utils.isStatic
@@ -924,13 +923,10 @@ class KotlinTypeMapping(
     }
 
     private fun javaArrayType(type: JavaArrayType, signature: String): JavaType {
-        val arrayType = Array(
-            null,
-            null
-        )
+        val arrayType = Array(null, null, null)
         typeCache.put(signature, arrayType)
         val classType = type(type.componentType)
-        arrayType.unsafeSet(classType)
+        arrayType.unsafeSet(classType, null)
         return arrayType
     }
 

--- a/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/KotlinTypeSignatureBuilder.kt
@@ -18,7 +18,6 @@ package org.openrewrite.kotlin
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.fir.*
 import org.jetbrains.kotlin.fir.declarations.*
-import org.jetbrains.kotlin.fir.declarations.impl.FirOuterClassTypeParameterRef
 import org.jetbrains.kotlin.fir.declarations.utils.classId
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.references.FirErrorNamedReference

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -242,8 +242,8 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
                         }
                     }
 
-                    is FirArrayOfCall -> {
-                        // `FirArrayOfCall` is not a `FirFunctionCall`, so a `JavaType$Method` is impossible.
+                    is FirArrayLiteral -> {
+                        // `FirArrayLiteral` is not a `FirFunctionCall`, so a `JavaType$Method` is impossible.
                         // The expression contains a type ref of the parameterized type, but cannot be added to a `MethodInvocation`.
                         null
                     }
@@ -359,7 +359,7 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
         val fir = primary(psi) ?: return null
         return when (fir) {
             is FirResolvedQualifier -> ExpressionType.QUALIFIER
-            is FirArrayOfCall -> ExpressionType.METHOD_INVOCATION
+            is FirArrayLiteral -> ExpressionType.METHOD_INVOCATION
             is FirFunctionCall -> {
                 if (fir.calleeReference is FirErrorNamedReference)
                     return null

--- a/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -242,11 +242,6 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
                         }
                     }
 
-                    is FirArrayLiteral -> {
-                        // `FirArrayLiteral` is not a `FirFunctionCall`, so a `JavaType$Method` is impossible.
-                        // The expression contains a type ref of the parameterized type, but cannot be added to a `MethodInvocation`.
-                        null
-                    }
                     else -> {
                         null
                     }


### PR DESCRIPTION
## What's changed?
* Kotlin version bumped to `1.9.22`
* usages of `rewrite-java` updated to the newest snapshot (`8.13.0-SNAPSHOT`)

## What's your motivation?
Between Kotlin `1.9.0` and `1.9.10` the signature of `FirSessionFactoryHelper.createSessionWithDependencies` method was changed. In our projects we use the newest Kotlin and `./gradlew rewriteRun` fails with `NoSuchMethodError`.

## Anything in particular you'd like reviewers to focus on?
According to the test case `AnnotationTest.arrayOfCallWithInAnnotation` the `FirArrayOfCall` was replaced with `FirArrayLiteral`. Do you think any additional handling is needed for that?

## Additional context
My local build resolved the snapshot dependency of `rewrite-java` so I fixed the compilation errors. Should I do that? I assume `rewrite-kotlin` and `rewrite-java` will be released together, right?

### Checklist
- [ ] ~~I've added unit tests to cover both positive and negative cases~~
- [ ] ~~I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)~~
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
