### PR TITLE
Add .dependsOn method for KotlinParser

### DIFF
--- a/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -19,7 +19,6 @@ import kotlin.Pair;
 import kotlin.Unit;
 import kotlin.annotation.AnnotationTarget;
 import kotlin.jvm.functions.Function1;
-import kotlin.random.Random;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.intellij.lang.annotations.Language;
@@ -102,7 +101,6 @@ import static org.jetbrains.kotlin.config.CommonConfigurationKeys.*;
 import static org.jetbrains.kotlin.config.JVMConfigurationKeys.DO_NOT_CLEAR_BINDING_CONTEXT;
 import static org.jetbrains.kotlin.config.JVMConfigurationKeys.LINK_VIA_SIGNATURES;
 import static org.jetbrains.kotlin.incremental.IncrementalFirJvmCompilerRunnerKt.configureBaseRoots;
-import static org.openrewrite.java.JavaParser.resolveSourcePathFromSourceText;
 
 @SuppressWarnings("CommentedOutCode")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class KotlinParserTest implements RewriteTest {
+
+    @Language("kotlin")
+    private String myClassDefinition = """
+        package foo.bar
+
+        class MyClass
+      """;
+
+    @Test
+    void classDefinitionFromDependsOn() {
+        rewriteRun(
+          spec -> spec.parser(KotlinParser.builder().dependsOn(myClassDefinition)),
+          kotlin(
+            """
+              import foo.bar.MyClass
+
+              val myClass: MyClass? = null
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.kotlin;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
@@ -23,17 +22,14 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class KotlinParserTest implements RewriteTest {
 
-    @Language("kotlin")
-    private String myClassDefinition = """
-      package foo.bar
-
-      class MyClass
-      """;
-
     @Test
     void classDefinitionFromDependsOn() {
         rewriteRun(
-          spec -> spec.parser(KotlinParser.builder().dependsOn(myClassDefinition)),
+          spec -> spec.parser(KotlinParser.builder().dependsOn("""
+            package foo.bar
+
+            class MyClass
+            """)),
           kotlin(
             """
               import foo.bar.MyClass
@@ -43,4 +39,5 @@ class KotlinParserTest implements RewriteTest {
           )
         );
     }
+
 }

--- a/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
+++ b/src/test/java/org/openrewrite/kotlin/KotlinParserTest.java
@@ -25,9 +25,9 @@ class KotlinParserTest implements RewriteTest {
 
     @Language("kotlin")
     private String myClassDefinition = """
-        package foo.bar
+      package foo.bar
 
-        class MyClass
+      class MyClass
       """;
 
     @Test


### PR DESCRIPTION
## What's changed?
Add `.dependsOn` method for KotlinParser

## What's your motivation?
- https://github.com/openrewrite/rewrite-kotlin/issues/616

## Anything in particular you'd like reviewers to focus on?
* The way I have to remove the sources from the returned list is not so nice. Perhaps there is a better way without refactoring the whole thing?
* Need to add tests

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
