### PR TITLE
`int` literals should return an `Integer` value

### DIFF
--- a/gradle/licenseHeader.txt
+++ b/gradle/licenseHeader.txt
@@ -1,4 +1,4 @@
-Copyright 2023 the original author or authors.
+Copyright ${year} the original author or authors.
 <p>
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -2096,9 +2096,13 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     @Override
     public J visitConstantExpression(KtConstantExpression expression, ExecutionContext data) {
         IElementType elementType = expression.getElementType();
+        JavaType.Primitive type = primitiveType(expression);
         Object value;
         if (elementType == KtNodeTypes.INTEGER_CONSTANT || elementType == KtNodeTypes.FLOAT_CONSTANT) {
             value = ParseUtilsKt.parseNumericLiteral(expression.getText(), elementType);
+            if (type == JavaType.Primitive.Int && value instanceof Long) {
+                value = ((Long) value).intValue();
+            }
         } else if (elementType == KtNodeTypes.BOOLEAN_CONSTANT) {
             value = ParseUtilsKt.parseBoolean(expression.getText());
         } else if (elementType == KtNodeTypes.CHARACTER_CONSTANT) {
@@ -2115,7 +2119,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 value,
                 expression.getText(),
                 null,
-                primitiveType(expression)
+                type
         );
     }
 

--- a/src/test/java/org/openrewrite/kotlin/tree/PrimitiveTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/PrimitiveTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.tree;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class PrimitiveTest implements RewriteTest {
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/pull/663")
+    @Test
+    void intValueIsInteger() {
+        rewriteRun(
+          kotlin(
+            """
+              fun foo() {
+                  val bar = 0
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.MethodDeclaration foo = (J.MethodDeclaration) cu.getStatements().get(0);
+                J.VariableDeclarations bar = (J.VariableDeclarations) foo.getBody().getStatements().get(0);
+                J.Literal zero = (J.Literal) bar.getVariables().get(0).getInitializer();
+                assertThat(zero.getType().getKeyword()).isEqualTo("int");
+                assertThat(zero.getValue()).isInstanceOf(Integer.class);
+            })
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/kotlin/tree/PrimitiveTest.java
+++ b/src/test/java/org/openrewrite/kotlin/tree/PrimitiveTest.java
@@ -27,7 +27,7 @@ class PrimitiveTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-spring/pull/663")
     @Test
-    void intValueIsInteger() {
+    void intZeroValueIsInteger() {
         rewriteRun(
           kotlin(
             """
@@ -45,4 +45,26 @@ class PrimitiveTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/pull/663")
+    @Test
+    void longZeroValueIsLong() {
+        rewriteRun(
+          kotlin(
+            """
+              fun foo() {
+                  val bar = 0L
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.MethodDeclaration foo = (J.MethodDeclaration) cu.getStatements().get(0);
+                J.VariableDeclarations bar = (J.VariableDeclarations) foo.getBody().getStatements().get(0);
+                J.Literal zero = (J.Literal) bar.getVariables().get(0).getInitializer();
+                assertThat(zero.getType().getKeyword()).isEqualTo("long");
+                assertThat(zero.getValue()).isInstanceOf(Long.class);
+            })
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?


## What's your motivation?
As discovered on
- https://github.com/openrewrite/rewrite-spring/pull/663