### PR TITLE
Do not run `RemoveUnusedLocalVariables` on PRs for `KotlinTypeGoat`

### DIFF
--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -15,3 +15,5 @@ concurrency:
 jobs:
   upload-patch:
     uses: openrewrite/gh-automation/.github/workflows/receive-pr.yml@main
+    with:
+      recipe: 'org.openrewrite.recipes.OpenRewriteBestPracticesSubset'

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,42 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+# Apply a subset of best practices to OpenRewrite recipes; typically run before committing changes.
+# Any differences produced by this recipe will result in code suggestion comments on pull requests.
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.recipes.OpenRewriteBestPracticesSubset
+displayName: OpenRewrite best practices
+description: Best practices for OpenRewrite recipe development.
+recipeList:
+  - org.openrewrite.recipes.JavaRecipeBestPractices
+  - org.openrewrite.recipes.RecipeTestingBestPractices
+  - org.openrewrite.recipes.RecipeNullabilityBestPractices
+  - org.openrewrite.java.OrderImports
+  - org.openrewrite.java.RemoveUnusedImports
+  - org.openrewrite.java.format.EmptyNewlineAtEndOfFile
+  - org.openrewrite.java.format.RemoveTrailingWhitespace
+  - org.openrewrite.staticanalysis.CompareEnumsWithEqualityOperator
+  - org.openrewrite.staticanalysis.InlineVariable
+  - org.openrewrite.staticanalysis.LambdaBlockToExpression
+  - org.openrewrite.staticanalysis.MissingOverrideAnnotation
+  - org.openrewrite.staticanalysis.OperatorWrap:
+      wrapOption: EOL
+  #- org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
+  #- org.openrewrite.staticanalysis.UnnecessaryThrows
+  - org.openrewrite.staticanalysis.UseDiamondOperator


### PR DESCRIPTION
## What's your motivation?
The recipe had wanted to use unused local variables which we need for our tests.